### PR TITLE
Fix build on OpenBSD (and probably others too)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -20,9 +20,12 @@
         ['OS!="win"', {
           'link_settings': {
             'libraries': [
-              '<!@(pkg-config --libs-only-l libvirt)'
+              '<!@(pkg-config --libs libvirt)'
             ]
-          }
+          },
+	  'cflags': [
+	    '<!@(pkg-config --cflags libvirt)'
+	  ],
         }]
       ]
     }


### PR DESCRIPTION
On for example OpenBSD the libs live in /usr/local/lib, and this
directory isn't searched by default which causes a linking failure
when only --libs-only-l is passed to pkg-config. Also, the CFLAGS need
to be adjusted.
