### PR TITLE
Fixes to get node-libvirt working on newer versions of node.js (v0.10.5)

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,8 @@
 {
   'targets': [
     {
-      'target_name': 'node-libvirt',
+      'target_name': 'libvirt',
+      'product_prefix': 'lib',
       'sources': [
         'src/node_libvirt.cc',
         'src/domain.cc',

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./build/Release/node-libvirt');
+module.exports = require('./build/Release/libvirt');

--- a/package.json
+++ b/package.json
@@ -19,5 +19,5 @@
   "engines": {
     "node": ">=0.6.0"
   },
-  "main": "build/Release/src/libvirt.node"
+  "main": "build/Release/libvirt.node"
 }


### PR DESCRIPTION
Renamed the target to 'libvirt' and added 'product_prefix' to match the
definition in src/node_libvirt.cc's NODE_MODULE. This fixes a problem building
and using the module using newer versions of node (0.10.5). Also updated
the 'main' path in the package.json.
