### PR TITLE
Segmentation Fault 11 When Accessing Exception Object

### DIFF
--- a/src/error.cc
+++ b/src/error.cc
@@ -200,11 +200,11 @@ namespace NodeLibvirt {
         } else if(property == level_symbol) {
             return scope.Close(Integer::New(error_->level));
         } else if(property == str1_symbol) {
-            return scope.Close(String::New(error_->str1));
+            return scope.Close(String::New(error_->str1 != NULL ? error_->str1 : ""));
         } else if(property == str2_symbol) {
-            return scope.Close(String::New(error_->str2));
+            return scope.Close(String::New(error_->str2 != NULL ? error_->str2 : ""));
         } else if(property == str3_symbol) {
-            return scope.Close(String::New(error_->str3));
+            return scope.Close(String::New(error_->str3 != NULL ? error_->str3 : ""));
         } else if(property == int1_symbol) {
             return scope.Close(Integer::New(error_->int1));
         } else if(property == int2_symbol) {


### PR DESCRIPTION
When using libvirt 1.0.5 (maybe earlier, not sure), and an exception is thrown from the node-libvirt, trying to inspect the "str3" property of the exception causes a segmentation fault 11 in node. This patches that problem by first ensuring the "str3" symbol is not null before passing it to v8::String::New, and adds the same guards to the "str1" and "str2"
symbols as well as a precaution.

---

I cannot reproduce the error using the 'test:///default' connection URI, but the following code will easily demonstrate the problem if you have access to a real hypervisor (I happen to be using Xen over TCP):

```
var libvirt = require('./build/Release/libvirt');

try {
    var hv = new libvirt.Hypervisor('xen+tcp://192.168.42.253:16509');
    hv.lookupDomainById(1);
} catch (e) {
    console.info(e.domain); // Works as expected
    console.info(e.code); // Works as expected
    console.info(e.message); // Works as expected
    console.info(e); // causes segfault, because of str3
}
```

The above will produce the following output using node.js v0.10.5 and libvirt 1.0.5:

```
libvirt: Xen Driver error : Domain not found: xenUnifiedDomainLookupByID
Segmentation fault: 11
```

After applying this patch, the only output is the first line; still haven't tracked down how to suppress that yet, but for now it's irrelevant to the segfault. 
