### PR TITLE
Change Domain::GetId so it only throws an exception when an actual error occurs

### DIFF
--- a/src/domain.cc
+++ b/src/domain.cc
@@ -543,7 +543,10 @@ namespace NodeLibvirt {
         id = virDomainGetID(domain->domain_);
 
         if(id == -1u) {
-            ThrowException(Error::New(virGetLastError()));
+            if (virGetLastError() != NULL) {
+                ThrowException(Error::New(virGetLastError()));
+            }
+
             return Null();
         }
 


### PR DESCRIPTION
Instead of blanketly throwing an exception when virDomainGetId returns -1, check to see if an actual error object exists in virGetLastError; if it does, then throw the exception as normal, and if it doesn't then just return null. This will allow the caller to handle a null domain id without having to clutter up the code with try/catch blocks for situations that might not be exceptional (i.e., the domain is simply not running).
