### PR TITLE
Added #ifdef for VIR_DOMAIN_PMSUSPENDED

### DIFF
--- a/src/domain.cc
+++ b/src/domain.cc
@@ -196,6 +196,11 @@ namespace NodeLibvirt {
         NODE_DEFINE_CONSTANT(object_tmpl, VIR_DOMAIN_SHUTOFF);
         NODE_DEFINE_CONSTANT(object_tmpl, VIR_DOMAIN_CRASHED);
 
+#ifdef VIR_DOMAIN_PMSUSPENDED
+        // If its available in libvirt.h, then make it available in node
+        NODE_DEFINE_CONSTANT(object_tmpl, VIR_DOMAIN_PMSUSPENDED);
+#endif
+
         //virDomainDeviceModifyFlags
         NODE_DEFINE_CONSTANT(object_tmpl, VIR_DOMAIN_DEVICE_MODIFY_CURRENT);
         NODE_DEFINE_CONSTANT(object_tmpl, VIR_DOMAIN_DEVICE_MODIFY_LIVE);


### PR DESCRIPTION
I'm not sure of the exact version that it showed up in libvirt, but the VIR_DOMAIN_PMSUSPENDED constant was made available back in January (http://libvirt.org/git/?p=libvirt.git;a=commit;h=e0642059367436c27bc031df3b03ccdc1d818350) in the libvirt library. To maintain backward compatibility for older versions of libvirt, the node constant is wrapped in #ifdef so as not to cause compilation problems.
