### PR TITLE
Updated Domain.toXml to accept flags

### DIFF
--- a/src/domain.cc
+++ b/src/domain.cc
@@ -786,21 +786,36 @@ NLV_WORKER_EXECUTE(Domain, SetMemory)
   data_ = true;
 }
 
+NAN_METHOD(Domain::ToXml)
+{
+  NanScope();
+  unsigned int flags = 0;
+  NanCallback *callback;
+  if (args.Length() > 1 && args[1]->IsFunction())
+  {
+    callback = new NanCallback(args[1].As<Function>());
+    flags = args[0]->IntegerValue();
+  } else if (args.Length() == 1 && args[0]->IsFunction()) {
+    callback = new NanCallback(args[0].As<Function>());
+  } else {
+    NanThrowTypeError("signature is callback or flags, callback");
+    NanReturnUndefined();
+  }
+  Domain *domain = ObjectWrap::Unwrap<Domain>(args.This());
+  NanAsyncQueueWorker(new ToXmlWorker(callback, domain->handle_, flags));
+  NanReturnUndefined();
+}
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, ToXml)
 NLV_WORKER_EXECUTE(Domain, ToXml)
 {
   NLV_WORKER_ASSERT_DOMAIN();
-
-  unsigned int flags = 0;
-  char *result = virDomainGetXMLDesc(Handle().ToDomain(), flags);
+  char *result = virDomainGetXMLDesc(Handle().ToDomain(), flags_);
   if (result == NULL) {
     SetVirError(virGetLastError());
     return;
   }
-
+  
   data_ = result;
-  free(result);
 }
 
 NLV_WORKER_METHOD_NO_ARGS(Domain, GetInfo)

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -816,6 +816,7 @@ NLV_WORKER_EXECUTE(Domain, ToXml)
   }
   
   data_ = result;
+  free(result);
 }
 
 NLV_WORKER_METHOD_NO_ARGS(Domain, GetInfo)

--- a/src/domain.h
+++ b/src/domain.h
@@ -323,13 +323,21 @@ private:
   NLV_PRIMITIVE_RETURN_WORKER(IsPersistent, bool);
   NLV_PRIMITIVE_RETURN_WORKER(IsUpdated, bool);
   NLV_PRIMITIVE_RETURN_WORKER(HasManagedSaveImage, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(ToXml, std::string);
   NLV_PRIMITIVE_RETURN_WORKER(GetSchedulerType, std::string);
   NLV_TYPED_PARAMETER_RETURN_WORKER(GetSchedulerParameters, virSchedParameter);
   NLV_OBJECT_RETURN_WORKER(GetSecurityLabel, virSecurityLabel);
   NLV_OBJECT_RETURN_WORKER(GetJobInfo, virDomainJobInfo);
   NLV_PRIMITIVE_RETURN_WORKER(GetCurrentSnapshot, std::string);
   NLV_PRIMITIVE_RETURN_WORKER(HasCurrentSnapshot, bool);
+
+  class ToXmlWorker : public PrimitiveReturnWorker<std::string> {
+    public:
+      ToXmlWorker(NanCallback *callback, const LibVirtHandle &handle, int flags = 0)
+        : PrimitiveReturnWorker(callback, handle), flags_(flags) {}
+      void Execute();
+    private:
+      unsigned int flags_;
+  };
 
   class SetAutostartWorker : public PrimitiveReturnWorker<bool> {
   public:


### PR DESCRIPTION
Previously `domain.toXml` did not accept flags, 0 was passed by default for this argument. I reworked this function to allow flags to be passed. This is helpful if you need to access secured portions of the XML like the VNC password. 

The flags argument is optional so this will not break existing calls. 