### PR TITLE
Fix build on node 0.12.7

### DIFF
--- a/src/error.cc
+++ b/src/error.cc
@@ -149,7 +149,7 @@ Error::Error(virErrorPtr error)
   error_ = error;
 }
 
-Local<Object> Error::New(virErrorPtr error)
+Local<Value> Error::New(virErrorPtr error)
 {
   NanEscapableScope();
 

--- a/src/error.h
+++ b/src/error.h
@@ -16,7 +16,7 @@ class Error : public ObjectWrap
 {
 public:
   static void Initialize(Handle<Object> exports);
-  static Local<Object> New(virErrorPtr error);
+  static Local<Value> New(virErrorPtr error);
 
 private:
   explicit Error(virErrorPtr error);


### PR DESCRIPTION
I had errors like:
```
 CXX(target) Release/obj.target/libvirt/src/worker.o
  CXX(target) Release/obj.target/libvirt/src/interface.o
  CXX(target) Release/obj.target/libvirt/src/network.o
  CXX(target) Release/obj.target/libvirt/src/network_filter.o
  CXX(target) Release/obj.target/libvirt/src/node_device.o
  CXX(target) Release/obj.target/libvirt/src/secret.o
  CXX(target) Release/obj.target/libvirt/src/storage_pool.o
  CXX(target) Release/obj.target/libvirt/src/storage_volume.o
  CXX(target) Release/obj.target/libvirt/src/domain.o
../src/domain.cc: In static member function ‘static void NodeLibvirt::Domain::SetSchedulerParameters(const v8::FunctionCallbackInfo<v8::Value>&)’:
../src/domain.cc:2002:48: error: call of overloaded ‘NanThrowError(v8::Local<v8::Object>)’ is ambiguous
     NanThrowError(Error::New(virGetLastError()));
                                                ^
../src/domain.cc:2002:48: note: candidates are:
In file included from ../src/error.h:5:0,
                 from ../src/domain.cc:3:
../node_modules/nan/nan.h:705:21: note: void NanThrowError(v8::Handle<v8::String>)
     NAN_INLINE void NanThrow ## NAME(v8::Handle<v8::String> errmsg) {          \
                     ^
../node_modules/nan/nan.h:711:3: note: in expansion of macro ‘X’
   X(Error)
   ^
../node_modules/nan/nan.h:719:19: note: void NanThrowError(v8::Handle<v8::Value>)
   NAN_INLINE void NanThrowError(v8::Handle<v8::Value> error) {
                   ^
../src/domain.cc:2017:48: error: call of overloaded ‘NanThrowError(v8::Local<v8::Object>)’ is ambiguous
     NanThrowError(Error::New(virGetLastError()));
                                                ^
../src/domain.cc:2017:48: note: candidates are:
In file included from ../src/error.h:5:0,
                 from ../src/domain.cc:3:
../node_modules/nan/nan.h:705:21: note: void NanThrowError(v8::Handle<v8::String>)
     NAN_INLINE void NanThrow ## NAME(v8::Handle<v8::String> errmsg) {          \
                     ^
../node_modules/nan/nan.h:711:3: note: in expansion of macro ‘X’
   X(Error)
   ^
../node_modules/nan/nan.h:719:19: note: void NanThrowError(v8::Handle<v8::Value>)
   NAN_INLINE void NanThrowError(v8::Handle<v8::Value> error) {
                   ^
../src/domain.cc:2054:48: error: call of overloaded ‘NanThrowError(v8::Local<v8::Object>)’ is ambiguous
     NanThrowError(Error::New(virGetLastError()));
                                                ^
../src/domain.cc:2054:48: note: candidates are:
In file included from ../src/error.h:5:0,
                 from ../src/domain.cc:3:
../node_modules/nan/nan.h:705:21: note: void NanThrowError(v8::Handle<v8::String>)
     NAN_INLINE void NanThrow ## NAME(v8::Handle<v8::String> errmsg) {          \
                     ^
../node_modules/nan/nan.h:711:3: note: in expansion of macro ‘X’
   X(Error)
   ^
../node_modules/nan/nan.h:719:19: note: void NanThrowError(v8::Handle<v8::Value>)
   NAN_INLINE void NanThrowError(v8::Handle<v8::Value> error) {
                   ^
make: *** [Release/obj.target/libvirt/src/domain.o] Error 1
```

This pull request fixes it.