### PR TITLE
Fix libvirt version string processing during testing

### DIFF
--- a/test/lib/helper.js
+++ b/test/lib/helper.js
@@ -13,7 +13,13 @@ module.exports = {
     return new Promise(function(resolve, reject) {
       cp.exec('pkg-config --modversion libvirt', function(err, stdout, stderr) {
         if (!!err) return reject(err);
-        resolve(stdout.trim());
+        // some versions return an extra "dot", e.g. Fedora 22 "1.2.13.1"
+        // which semver can't handle
+        var verString = stdout.trim();
+        var verParts = verString.split(/\./);
+        verParts.splice(3, verParts.length - 3);
+        verString = verParts.join('.');
+        resolve(verString);
       });
     });
   }


### PR DESCRIPTION
On my Fedora version, the "helper" method to get the libvirt version for tests returns an extra "dot" version (e.g. the string "1.2.13.1" from Fedora 23) which semver can't handle.

This causes many of the tests to fail.

This fix removes the extra "node" from the version string and all tests pass.