### PR TITLE
Memory freed with delete[] must be allocated with new[]

### DIFF
--- a/src/hypervisor.cc
+++ b/src/hypervisor.cc
@@ -599,7 +599,7 @@ NLV_WORKER_EXECUTE(Hypervisor, CompareCPU)
       SetVirError(virGetLastError()); \
       return; \
     } \
-    char **names = (char **)malloc(sizeof(*names) * count); \
+    char **names = new char*[count]; \
     if (names == NULL) {  \
       SetErrorMessage("could not allocate memory"); \
       return; \
@@ -625,7 +625,7 @@ NLV_WORKER_EXECUTE(Hypervisor, CompareCPU)
       SetVirError(virGetLastError()); \
       return; \
     } \
-    int *elements = (int *)malloc(sizeof(*elements) * count); \
+    int *elements = new int[count]; \
     if (elements == NULL) {  \
       SetErrorMessage("could not allocate memory"); \
       delete [] elements; \
@@ -748,7 +748,7 @@ NLV_WORKER_EXECUTE(Hypervisor, ListNodeDevices)
     return;
   }
 
-  char **names = (char **) malloc(sizeof(*names) * num_devices);
+  char **names = new char*[num_devices];
   if (names == NULL) {
     SetErrorMessage("unable to allocate memory");
     return;


### PR DESCRIPTION
This fixes some complaints that valgrind was making.
----------------------------
Still tracking down the segfault - although I did find a use-after-free bug in libvirt which seems definitely suspicious.

However, I think more to the point is that node is doing a GC right before the segfault.  I have added a print statement to the NLVObject destructor and it prints a raft of destroyed objects, and then poof.

In fact, I can verify with my print statements that some object is still being referenced in the "children" array of it's parent after it's destructor is called.  So when the "clear" trickles down, the vector has been destroyed and the iterator crashes.

This could happen in, e.g. the storage_volume.test.js "should be located by its path" test because by the time the "done()" closure in the test-suite gets called, the entire context that holds reference to the "other" volume (that is fetched by path) has been discarded and that object is ok to be freed, but it's still in the hypervisor's children array.

I think a Persistent<NLVObject> reference will need to be added to the children_ vector instead of the pointer.  This will hold the reference until the children array is "cleared".

I'll attempt this fix now and if it works you will see another pull request ;-)
