### PR TITLE
Use a Persistent reference to prevent GC of objects that still need cleanup

### DIFF
--- a/src/nlv_async_worker.h
+++ b/src/nlv_async_worker.h
@@ -219,8 +219,9 @@ protected:
   virtual void HandleOKCallback() {
     NanScope();
     Local<Object> childObject = InstanceClass::NewInstance(lookupHandle_);
-    InstanceClass *child = ObjectWrap::Unwrap<InstanceClass>(childObject);
-    parent_->children_.push_back(child);
+    Persistent<Object> persistentHandle;
+    NanAssignPersistent(persistentHandle, childObject);
+    parent_->children_.push_back(persistentHandle);
     v8::Local<v8::Value> argv[] = { NanNull(), childObject };
     callback->Call(2, argv);
   }
@@ -228,7 +229,6 @@ protected:
   ParentClass *parent_;
   std::string value_;
   InstanceHandleType lookupHandle_;
-
 };
 
 #endif  // NLV_ASYNC_WORKER_H

--- a/src/nlv_object.h
+++ b/src/nlv_object.h
@@ -33,8 +33,7 @@ public:
   virtual void ClearChildren() {
     std::vector< Persistent<Object> >::const_iterator it;
     for (it = children_.begin(); it != children_.end(); ++it) {
-      Persistent<Object> persistentRef = *it;
-      NLVObjectBase *obj = ObjectWrap::Unwrap<NLVObject>(persistentRef);
+      NLVObjectBase *obj = ObjectWrap::Unwrap<NLVObject>(*it);
       obj->ClearChildren();
       obj->ClearHandle();
     }

--- a/src/nlv_object.h
+++ b/src/nlv_object.h
@@ -31,16 +31,18 @@ public:
   }
 
   virtual void ClearChildren() {
-    std::vector<NLVObjectBase*>::const_iterator it;
+    std::vector< Persistent<Object> >::const_iterator it;
     for (it = children_.begin(); it != children_.end(); ++it) {
-      (*it)->ClearChildren();
-      (*it)->ClearHandle();
+      Persistent<Object> persistentRef = *it;
+      NLVObjectBase *obj = ObjectWrap::Unwrap<NLVObject>(persistentRef);
+      obj->ClearChildren();
+      obj->ClearHandle();
     }
 
     children_.clear();
   }
 
-  std::vector<NLVObjectBase*> children_;
+  std::vector< Persistent<Object> > children_;
 
 protected:
   HandleType handle_;


### PR DESCRIPTION
I really don't know if this is 100% right.  Someone with better v8/NaN foo should look it over.  Anyway, I think it's on the right track.

BUT:

1) no more segfault that I can reproduce (I made the tests run 100x  consecutively in the same test run and it was stable)
2) objects ARE still being destroyed (a print statement in ~NLVObject() will confirm)

However, I think there's a leak somewhere (could have been there all along). During the 100x test runs memory usage was constantly growing.