### PR TITLE
Use a class to hold child references. Handles GC cleanup of child before parent

### DIFF
--- a/src/nlv_async_worker.h
+++ b/src/nlv_async_worker.h
@@ -8,6 +8,8 @@
 
 #include <vector>
 
+#include "nlv_object.h"
+
 /**
  * Base class for all workers in node-libvirt
  */
@@ -220,7 +222,9 @@ protected:
     NanScope();
     Local<Object> childObject = InstanceClass::NewInstance(lookupHandle_);
     InstanceClass *child = ObjectWrap::Unwrap<InstanceClass>(childObject);
-    parent_->children_.push_back(child);
+    NLVObjectBasePtr *childPtr = new NLVObjectBasePtr(child);
+    child->SetParentReference(childPtr);
+    parent_->children_.push_back(childPtr);
     v8::Local<v8::Value> argv[] = { NanNull(), childObject };
     callback->Call(2, argv);
   }


### PR DESCRIPTION
WIP.

Except for the "don't call virtual functions in destructor" issue (which is working in practice unless subclasses exist which override ClearHandle(), (unless I'm missing something)).

I've tested and it also works.  I can reproduce the case where the GC has cleared the underlying NLVObject and the parent reference is "marked" invalid. Later when we top-down cleanup, the reference is skipped.
