### PR TITLE
Implement domain metadata accessors

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "segfault-handler": "^0.2.4",
-    "semver": "^5.0.1"
+    "semver": "^5.0.1",
+    "xpath": "~0.0.9",
+    "xmldom": "~0.1.19"
   }
 }

--- a/src/domain.h
+++ b/src/domain.h
@@ -93,6 +93,8 @@ private:
   static NAN_METHOD(GetVcpus);
   static NAN_METHOD(SetVcpus);
   static NAN_METHOD(ToXml);
+  static NAN_METHOD(GetMetadata);
+  static NAN_METHOD(SetMetadata);
   static NAN_METHOD(GetCurrentSnapshot);
   static NAN_METHOD(SetMigrationMaxDowntime);
   static NAN_METHOD(HasCurrentSnapshot);
@@ -340,6 +342,37 @@ private:
         : NLVPrimitiveReturnWorker<virDomainPtr, std::string>(callback, handle), flags_(flags) {}
       void Execute();
     private:
+      unsigned int flags_;
+  };
+
+  class GetMetadataWorker : public NLVPrimitiveReturnWorker<virDomainPtr, std::string> {
+    public:
+      GetMetadataWorker(NanCallback *callback, virDomainPtr handle, int type, const std::string &namespace_uri, unsigned int flags)
+        : NLVPrimitiveReturnWorker<virDomainPtr, std::string>(callback, handle), type_(type), namespace_uri_(namespace_uri), flags_(flags) {}
+      void Execute();
+    private:
+      int type_;
+      std::string namespace_uri_;
+      unsigned int flags_;
+  };
+
+  class SetMetadataWorker : public NLVPrimitiveReturnWorker<virDomainPtr, bool> {
+    public:
+      SetMetadataWorker(NanCallback *callback, virDomainPtr handle,
+	      int type, bool null_metadata,
+	      const std::string &metadata, const std::string &namespace_key,
+	      const std::string &namespace_uri, unsigned int flags)
+        : NLVPrimitiveReturnWorker<virDomainPtr, bool>(callback, handle),
+	  type_(type), null_metadata_(null_metadata),
+	  metadata_(metadata), namespace_key_(namespace_key),
+	  namespace_uri_(namespace_uri), flags_(flags) {}
+      void Execute();
+    private:
+      int type_;
+      bool null_metadata_;
+      std::string metadata_;
+      std::string namespace_key_;
+      std::string namespace_uri_;
       unsigned int flags_;
   };
 

--- a/test/domain_metadata.test.js
+++ b/test/domain_metadata.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+var libvirt = require('../lib'),
+    Hypervisor = libvirt.Hypervisor,
+    SegfaultHandler = require('segfault-handler'),
+    h = require('./lib/helper'),
+    semver = require('semver'),
+    expect = require('chai').expect,
+    xpath = require('xpath'),
+    dom = require('xmldom').DOMParser;
+
+var test = {};
+
+function verifyMetadata(test, expectedFromApi, expectedFromXml, namespaceUri, done) {
+    test.domain.getMetadata(libvirt.VIR_DOMAIN_METADATA_ELEMENT, namespaceUri, 0, function(err, xml) {
+        if (expectedFromApi === null) {
+            expect(err).to.exist;
+            expect(xml).to.be.undefined;
+        } else {
+            expect(err).to.not.exist;
+            xml = xml.replace(/"/g, "'");
+            expect(xml).to.equal(expectedFromApi);
+        }
+        getMetadataFromXml(test, function(err, xml) {
+            expect(err).to.not.exist;
+            if (expectedFromXml === null) {
+                expect(xml).to.be.undefined;
+            } else {
+                xml = xml.replace(/"/g, "'");
+                expect(xml).to.equal(expectedFromXml);
+            }
+            done();
+        });
+    });
+}
+
+function getMetadataFromXml(test, callback) {
+    test.domain.toXml(function(err, xml) {
+        if (err) {
+            callback(err);
+        } else {
+            var doc = new dom().parseFromString(xml);
+            var nodes = xpath.select("//metadata/*", doc);
+            expect(nodes.length).to.be.below(2);
+            xml = nodes.length === 1 ? nodes[0].toString() : undefined;
+            callback(null, xml);
+        }
+    });
+}
+
+function testText(test, field, str, shouldPass, done) {
+
+    var _without_this_str_is_null_when_passed_to_native_in_some_cases = 1;
+
+    test.domain.setMetadata(field, str, null, null, 0, function(err) {
+        if (err) {
+            if (shouldPass) {
+                expect(err).to.not.exist;
+            } else {
+                expect(err).to.exist;
+            }
+            done();
+        } else {
+            test.domain.getMetadata(field, null, 0, function(err, md) {
+                // value not present is returned as "error" (and so undefined)
+                if (str !== null) {
+                    expect(err).to.not.exist;
+                } else {
+                    str = undefined;
+                }
+                expect(md).to.equal(str);
+                done();
+            });
+        }
+    });
+}
+
+describe('Domain', function() {
+    before(function() {
+        SegfaultHandler.registerHandler();
+        return h.getLibVirtVersion()
+        .then(function(version) {
+            test.version = version;
+        });
+    });
+
+    describe('metadata methods', function() {
+        beforeEach(function(done) {
+            test.hypervisor = new Hypervisor('test:///default');
+            test.hypervisor.connect(function(err) {
+                expect(err).to.not.exist;
+
+                test.hypervisor.lookupDomainById(1, function(err, domain) {
+                    expect(err).to.not.exist;
+                    expect(domain).to.exist;
+                    test.domain = domain;
+                    done();
+                });
+            });
+        });
+
+        afterEach(function(done) {
+            test.hypervisor.disconnect(function(err) {
+                expect(err).to.not.exist;
+                done();
+            });
+        });
+
+        it('should set domain element metadata', function(done) {
+            var metadata1 = h.fixture("metadata1.xml");
+            metadata1 = metadata1.trim();
+            var metadata1_ns = h.fixture("metadata1_ns.xml");
+            metadata1_ns = metadata1_ns.trim();
+            test.domain.setMetadata(libvirt.VIR_DOMAIN_METADATA_ELEMENT, metadata1, "herp", "http://herp.derp/", 0,
+                function(err) {
+                    expect(err).to.not.exist;
+                    verifyMetadata(test, metadata1, metadata1_ns, "http://herp.derp/", done);
+                }
+            );
+        });
+        
+        it('should rewrite domain element metadata', function(done) {
+            var metadata2 = h.fixture("metadata2.xml");
+            metadata2 = metadata2.trim();
+            var metadata2_ns = h.fixture("metadata2_ns.xml");
+            metadata2_ns = metadata2_ns.trim();
+            test.domain.setMetadata(libvirt.VIR_DOMAIN_METADATA_ELEMENT, metadata2, "blurb", "http://herp.derp/", 0, 
+                function(err) {
+                    expect(err).to.not.exist;
+                    verifyMetadata(test, metadata2, metadata2_ns, "http://herp.derp/", done);
+                }
+            );
+        });
+
+        it('should erase domain element metadata', function(done) {
+            test.domain.setMetadata(libvirt.VIR_DOMAIN_METADATA_ELEMENT, null, "", "http://herp.derp/", 0,
+                function(err) {
+                    expect(err).to.not.exist;
+                    verifyMetadata(test, null, null, "http://herp.derp/", done);
+                }
+            );
+        });
+
+        var titleTests = [
+            [1, "qwert",		true  ]
+            , [2, null, 		true  ]
+            , [3, "blah", 		true  ]
+            , [4, "qwe\nrt", 	false ]
+            , [5, "", 			true  ]
+            , [6, "qwert\n", 	false ]
+            , [7, "\n",		false ]
+        ];
+
+        titleTests.forEach(function(tt) {
+            it('should manipulate the title test#'+tt[0], function(done) {
+                testText(test, libvirt.VIR_DOMAIN_METADATA_TITLE, tt[1], tt[2], done);
+            });
+        });
+
+        var descriptionTests = [
+            [1, "qwert\nqwert"]
+            , [2, null]
+            , [3, ""]
+            , [4, "qwert"]
+            , [5, "\n"]
+            , [6, "qwert\n"]
+            , [7, "\nqwert"]
+        ];
+
+        descriptionTests.forEach(function(tt) {
+            it('should manipulate the description test#'+tt[0], function(done) {
+                testText(test, libvirt.VIR_DOMAIN_METADATA_DESCRIPTION, tt[1], true, done);
+            });
+        });
+    });
+});

--- a/test/fixtures/metadata1.xml
+++ b/test/fixtures/metadata1.xml
@@ -1,0 +1,5 @@
+<derp xmlns:foobar='http://foo.bar/'>
+  <bar>foobar</bar>
+  <foo fooish='blurb'>foofoo</foo>
+  <foobar:baz>zomg</foobar:baz>
+</derp>

--- a/test/fixtures/metadata1_ns.xml
+++ b/test/fixtures/metadata1_ns.xml
@@ -1,0 +1,5 @@
+<herp:derp xmlns:foobar='http://foo.bar/' xmlns:herp='http://herp.derp/'>
+  <herp:bar>foobar</herp:bar>
+  <herp:foo fooish='blurb'>foofoo</herp:foo>
+  <foobar:baz>zomg</foobar:baz>
+</herp:derp>

--- a/test/fixtures/metadata2.xml
+++ b/test/fixtures/metadata2.xml
@@ -1,0 +1,3 @@
+<foo>
+  <bar>baz</bar>
+</foo>

--- a/test/fixtures/metadata2_ns.xml
+++ b/test/fixtures/metadata2_ns.xml
@@ -1,0 +1,3 @@
+<blurb:foo xmlns:blurb='http://herp.derp/'>
+  <blurb:bar>baz</blurb:bar>
+</blurb:foo>


### PR DESCRIPTION
This pull request implements the domain metadata accessors, which can be used for the "title", "description" and custom "metadata" XML content for a domain.

Tests have been implemented in a separate js.

