### PR TITLE
refactor(parents): add parents to all looked up child objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ jshint:
 fixjsstyle:
 	fixjsstyle -r lib -r test --strict --jslint_error=all
 
-test:
+test:	jshint
 	@if [ "$$GREP" ]; then \
-		make jshint && $(NPM_BIN)/mocha --globals setImmediate,clearImmediate --check-leaks --colors -t 10000 --reporter $(REPORTER) -g "$$GREP" $(TESTS); \
+		$(NPM_BIN)/mocha --globals setImmediate,clearImmediate --check-leaks --colors -t 10000 --reporter $(REPORTER) -g "$$GREP" $(TESTS); \
 	else \
-		make jshint && $(NPM_BIN)/mocha --globals setImmediate,clearImmediate --check-leaks --colors -t 10000 --reporter $(REPORTER) $(TESTS); \
+		$(NPM_BIN)/mocha --globals setImmediate,clearImmediate --check-leaks --colors -t 10000 --reporter $(REPORTER) $(TESTS); \
 	fi
 
 .PHONY: jshint fixjsstyle test

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -233,7 +233,7 @@ NAN_METHOD(Domain::LookupByName)
   Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(info.This());
   std::string name(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByNameWorker(callback, hv, name));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByNameWorker(callback, hv, name), info.This());
   return;
 }
 
@@ -255,7 +255,7 @@ NAN_METHOD(Domain::LookupByUUID)
   Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(info.This());
   std::string uuid(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByUUIDWorker(callback, hv, uuid));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByUUIDWorker(callback, hv, uuid), info.This());
   return;
 }
 
@@ -276,7 +276,7 @@ NAN_METHOD(Domain::LookupById)
   Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(info.This());
   int id = info[0]->IntegerValue();
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByIdWorker(callback, hv, id));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByIdWorker(callback, hv, id), info.This());
   return;
 }
 

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -113,7 +113,7 @@ NAN_METHOD(Interface::LookupByName)
   Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(object);
   std::string name(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByNameWorker(callback, hv, name));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByNameWorker(callback, hv, name), info.This());
   return;
 }
 
@@ -136,7 +136,7 @@ NAN_METHOD(Interface::LookupByMacAddress)
   Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(object);
   std::string uuid(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByMacAddressWorker(callback, hv, uuid));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByMacAddressWorker(callback, hv, uuid), info.This());
   return;
 }
 

--- a/src/network.cc
+++ b/src/network.cc
@@ -58,7 +58,7 @@ NAN_METHOD(Network::LookupByName)
   Hypervisor *hv = ObjectWrap::Unwrap<Hypervisor>(info.This());
   std::string name(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByNameWorker(callback, hv, name));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByNameWorker(callback, hv, name), info.This());
   return;
 }
 
@@ -80,7 +80,7 @@ NAN_METHOD(Network::LookupByUUID)
   Hypervisor *hv = ObjectWrap::Unwrap<Hypervisor>(info.This());
   std::string uuid(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByUUIDWorker(callback, hv, uuid));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByUUIDWorker(callback, hv, uuid), info.This());
   return;
 }
 

--- a/src/nlv_object.h
+++ b/src/nlv_object.h
@@ -18,16 +18,19 @@ public:
   NLVObjectBasePtr(NLVObjectBase *ref) : ref_(ref), valid_(true) {}
   bool IsValid() const { return valid_; }
   NLVObjectBase* GetPointer() const {
-      if (!valid_) {
-         //Nan::ThrowReferenceError("attempt to access invalid NLVObjectBase pointer");
-	 return NULL;
-      }
-      return ref_;
+    if (!valid_) {
+      //Nan::ThrowReferenceError("attempt to access invalid NLVObjectBase pointer");
+      return NULL;
+    }
+
+    return ref_;
   }
+
   void SetInvalid() {
-      ref_ = NULL;
-      valid_ = false;
+    ref_ = NULL;
+    valid_ = false;
   }
+
 protected:
   NLVObjectBase *ref_;
   bool valid_;
@@ -47,11 +50,11 @@ class NLVObject : public NLVObjectBase
 public:
   NLVObject(HandleType handle) : handle_(handle), parentReference_(NULL) {}
   ~NLVObject() {
-      // calling virtual ClearHandle() will break if overridden by subclasses
-      ClearHandle();
-      if (parentReference_ != NULL) {
-	  parentReference_->SetInvalid();
-      }
+    // calling virtual ClearHandle() will break if overridden by subclasses
+    ClearHandle();
+    if (parentReference_ != NULL) {
+      parentReference_->SetInvalid();
+    }
   }
 
   virtual void ClearHandle() {
@@ -79,7 +82,7 @@ public:
   }
 
   virtual void SetParentReference(NLVObjectBasePtr *parentReference) {
-      parentReference_ = parentReference;
+    parentReference_ = parentReference;
   }
 
   std::vector<NLVObjectBasePtr*> children_;
@@ -87,6 +90,7 @@ public:
 protected:
   HandleType handle_;
   NLVObjectBasePtr* parentReference_;
+
 };
 
 #endif  // NLV_OBJECT_H

--- a/src/storage_pool.cc
+++ b/src/storage_pool.cc
@@ -87,7 +87,7 @@ NAN_METHOD(StoragePool::LookupByName)
   Hypervisor *hv = ObjectWrap::Unwrap<Hypervisor>(object);
   std::string name(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByNameWorker(callback, hv, name));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByNameWorker(callback, hv, name), info.This());
   return;
 }
 
@@ -109,7 +109,7 @@ NAN_METHOD(StoragePool::LookupByUUID)
   Hypervisor *hv = ObjectWrap::Unwrap<Hypervisor>(info.This());
   std::string uuid(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByUUIDWorker(callback, hv, uuid));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByUUIDWorker(callback, hv, uuid), info.This());
   return;
 }
 
@@ -136,7 +136,7 @@ NAN_METHOD(StoragePool::Create)
   Hypervisor *hv = ObjectWrap::Unwrap<Hypervisor>(info.This());
   std::string xmlData(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new CreateWorker(callback, hv, xmlData));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new CreateWorker(callback, hv, xmlData), info.This());
   return;
 }
 

--- a/src/storage_volume.cc
+++ b/src/storage_volume.cc
@@ -65,7 +65,7 @@ NAN_METHOD(StorageVolume::Create)
   StoragePool *sp = Nan::ObjectWrap::Unwrap<StoragePool>(info.This());
   std::string xmlData(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new CreateWorker(callback, sp, xmlData));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new CreateWorker(callback, sp, xmlData), info.This());
   return;
 }
 
@@ -217,7 +217,7 @@ NAN_METHOD(StorageVolume::LookupByName)
   StoragePool *sp = Nan::ObjectWrap::Unwrap<StoragePool>(object);
   std::string name(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByNameWorker(callback, sp, name));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByNameWorker(callback, sp, name), info.This());
   return;
 }
 
@@ -240,7 +240,7 @@ NAN_METHOD(StorageVolume::LookupByKey)
   Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(object);
   std::string key(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByKeyWorker(callback, hv, key));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByKeyWorker(callback, hv, key), info.This());
   return;
 }
 
@@ -263,7 +263,7 @@ NAN_METHOD(StorageVolume::LookupByPath)
   Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(object);
   std::string path(*Nan::Utf8String(info[0]->ToString()));
   Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());
-  Nan::AsyncQueueWorker(new LookupByPathWorker(callback, hv, path));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new LookupByPathWorker(callback, hv, path), info.This());
   return;
 }
 
@@ -299,9 +299,8 @@ NAN_METHOD(StorageVolume::Clone)
   std::string xml(*Nan::Utf8String(info[1]->ToString()));
   StoragePool *sp = Nan::ObjectWrap::Unwrap<StoragePool>(object);
   StorageVolume *sv = Nan::ObjectWrap::Unwrap<StorageVolume>(info[0]->ToObject());
-
   Nan::Callback *callback = new Nan::Callback(info[2].As<Function>());
-  Nan::AsyncQueueWorker(new CloneWorker(callback, sp, xml, sv->handle_));
+  NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new CloneWorker(callback, sp, xml, sv->handle_), info.This());
   return;
 }
 

--- a/src/worker_macros.h
+++ b/src/worker_macros.h
@@ -67,7 +67,7 @@
     Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(info.This()); \
     std::string xmlData(*Nan::Utf8String(info[0]->ToString())); \
     Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());  \
-    Nan::AsyncQueueWorker(new DefineWorker(callback, hv, xmlData));  \
+    NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new DefineWorker(callback, hv, xmlData), info.This()); \
     return; \
   }
 
@@ -86,7 +86,7 @@
     Hypervisor *hv = Nan::ObjectWrap::Unwrap<Hypervisor>(info.This()); \
     std::string xmlData(*Nan::Utf8String(info[0]->ToString())); \
     Nan::Callback *callback = new Nan::Callback(info[1].As<Function>());  \
-    Nan::AsyncQueueWorker(new CreateWorker(callback, hv, xmlData));  \
+    NLV_ASYNC_QUEUE_WORKER_WITH_PARENT(new CreateWorker(callback, hv, xmlData), info.This()); \
     return; \
   }
 

--- a/test/domain.test.js
+++ b/test/domain.test.js
@@ -37,6 +37,7 @@ describe('Domain', function() {
       test.hypervisor.lookupDomainById(1, function(err, domain) {
         expect(err).to.not.exist;
         expect(domain).to.exist;
+        expect(domain._parent).to.exist;
         done();
       });
     });
@@ -46,9 +47,12 @@ describe('Domain', function() {
       test.hypervisor.createDomain(xml, function(err, domain) {
         expect(err).to.not.exist;
         expect(domain).to.exist;
+        expect(domain._parent).to.exist;
 
         test.hypervisor.lookupDomainByName('nodejs-test', function(err, lookupDomain) {
           expect(err).to.not.exist;
+          expect(lookupDomain).to.exist;
+          expect(lookupDomain._parent).to.exist;
 
           lookupDomain.getName(function(err, name) {
             expect(err).to.not.exist;
@@ -69,9 +73,12 @@ describe('Domain', function() {
       test.hypervisor.defineDomain(xml, function(err, domain) {
         expect(err).to.not.exist;
         expect(domain).to.exist;
+        expect(domain._parent).to.exist;
 
         test.hypervisor.lookupDomainByName('nodejs-test', function(err, lookupDomain) {
           expect(err).to.not.exist;
+          expect(lookupDomain).to.exist;
+          expect(lookupDomain._parent).to.exist;
 
           lookupDomain.undefine(function(err, result) {
             expect(err).to.not.exist;
@@ -96,6 +103,7 @@ describe('Domain', function() {
         test.hypervisor.lookupDomainById(1, function(err, domain) {
           expect(err).to.not.exist;
           expect(domain).to.exist;
+          expect(domain._parent).to.exist;
           test.domain = domain;
           done();
         });
@@ -303,7 +311,7 @@ describe('Domain', function() {
 
       test.domain.migrate({ dest_uri: 'test:///default', dest_name: 'test2', bandwidth: 100, flags: flags }, function(err) {
         expect(err).to.exist;
-        // some libvirt versions report different error codes. 
+        // some libvirt versions report different error codes.
         var expected = err.code === libvirt.VIR_ERR_OPERATION_INVALID ? libvirt.VIR_ERR_OPERATION_INVALID : libvirt.VIR_ERR_NO_SUPPORT;
         expect(err.code).to.be.equal(expected);
 
@@ -436,6 +444,7 @@ describe('Domain', function() {
         test.hypervisor.lookupDomainById(1, function(err, domain) {
           expect(err).to.not.exist;
           expect(domain).to.exist;
+          expect(domain._parent).to.exist;
           test.domain = domain;
           done();
         });

--- a/test/domain_metadata.test.js
+++ b/test/domain_metadata.test.js
@@ -7,7 +7,7 @@ var libvirt = require('../lib'),
     semver = require('semver'),
     expect = require('chai').expect,
     xpath = require('xpath'),
-    dom = require('xmldom').DOMParser;
+    Dom = require('xmldom').DOMParser;
 
 var test = {};
 
@@ -39,7 +39,7 @@ function getMetadataFromXml(test, callback) {
         if (err) {
             callback(err);
         } else {
-            var doc = new dom().parseFromString(xml);
+            var doc = new Dom().parseFromString(xml);
             var nodes = xpath.select("//metadata/*", doc);
             expect(nodes.length).to.be.below(2);
             xml = nodes.length === 1 ? nodes[0].toString() : undefined;
@@ -119,14 +119,14 @@ describe('Domain', function() {
                 }
             );
         });
-        
+
         it('should rewrite domain element metadata', function(done) {
             if (semver.lt(test.version, '0.9.10')) { return done(); }
             var metadata2 = h.fixture("metadata2.xml");
             metadata2 = metadata2.trim();
             var metadata2_ns = h.fixture("metadata2_ns.xml");
             metadata2_ns = metadata2_ns.trim();
-            test.domain.setMetadata(libvirt.VIR_DOMAIN_METADATA_ELEMENT, metadata2, "blurb", "http://herp.derp/", 0, 
+            test.domain.setMetadata(libvirt.VIR_DOMAIN_METADATA_ELEMENT, metadata2, "blurb", "http://herp.derp/", 0,
                 function(err) {
                     expect(err).to.not.exist;
                     verifyMetadata(test, metadata2, metadata2_ns, "http://herp.derp/", done);

--- a/test/domain_metadata.test.js
+++ b/test/domain_metadata.test.js
@@ -93,6 +93,7 @@ describe('Domain', function() {
                 test.hypervisor.lookupDomainById(1, function(err, domain) {
                     expect(err).to.not.exist;
                     expect(domain).to.exist;
+                    expect(domain._parent).to.exist;
                     test.domain = domain;
                     done();
                 });

--- a/test/interface.test.js
+++ b/test/interface.test.js
@@ -33,6 +33,7 @@ describe('Interface', function() {
       test.hypervisor.defineInterface(xml, function(err, iface) {
         expect(err).to.not.exist;
         expect(iface).to.exist;
+        expect(iface._parent).to.exist;
 
         iface.getName(function(err, result) {
           expect(err).to.not.exist;
@@ -47,10 +48,12 @@ describe('Interface', function() {
       test.hypervisor.defineInterface(xml, function(err, iface) {
         expect(err).to.not.exist;
         expect(iface).to.exist;
+        expect(iface._parent).to.exist;
 
         test.hypervisor.lookupInterfaceByName('eth2', function(err, iface) {
           expect(err).to.not.exist;
           expect(iface).to.exist;
+          expect(iface._parent).to.exist;
           iface.undefine(function(err, result) {
             expect(err).to.not.exist;
             expect(result).to.be.true;
@@ -64,6 +67,7 @@ describe('Interface', function() {
       test.hypervisor.lookupInterfaceByName('eth1', function(err, iface) {
         expect(err).to.not.exist;
         expect(iface).to.exist;
+        expect(iface._parent).to.exist;
 
         iface.getName(function(err, result) {
           expect(err).to.not.exist;
@@ -77,6 +81,7 @@ describe('Interface', function() {
       test.hypervisor.lookupInterfaceByMacAddress('aa:bb:cc:dd:ee:ff', function(err, iface) {
         expect(err).to.not.exist;
         expect(iface).to.exist;
+        expect(iface._parent).to.exist;
 
         iface.getName(function(err, result) {
           expect(err).to.not.exist;
@@ -95,6 +100,7 @@ describe('Interface', function() {
         test.hypervisor.lookupInterfaceByName('eth1', function(err, iface) {
           expect(err).to.not.exist;
           expect(iface).to.exist;
+          expect(iface._parent).to.exist;
           test.interface = iface;
           done();
         });

--- a/test/network.test.js
+++ b/test/network.test.js
@@ -33,6 +33,7 @@ describe('Network', function() {
       test.hypervisor.defineNetwork(xml, function(err, network) {
         expect(err).to.not.exist;
         expect(network).to.exist;
+        expect(network._parent).to.exist;
 
         network.start(function(err, result) {
           expect(err).to.not.exist;
@@ -47,6 +48,7 @@ describe('Network', function() {
       test.hypervisor.createNetwork(xml, function(err, network) {
         expect(err).to.not.exist;
         expect(network).to.exist;
+        expect(network._parent).to.exist;
 
         network.getName(function(err, name) {
           expect(err).to.not.exist;
@@ -61,6 +63,7 @@ describe('Network', function() {
       test.hypervisor.lookupNetworkByName('default', function(err, network) {
         expect(err).to.not.exist;
         expect(network).to.exist;
+        expect(network._parent).to.exist;
 
         network.getName(function(err, name) {
           expect(err).to.not.exist;
@@ -76,6 +79,7 @@ describe('Network', function() {
       test.hypervisor.defineNetwork(xml, function(err, network) {
         expect(err).to.not.exist;
         expect(network).to.exist;
+        expect(network._parent).to.exist;
 
         network.getName(function(err, name) {
           expect(err).to.not.exist;
@@ -96,6 +100,7 @@ describe('Network', function() {
         test.hypervisor.lookupNetworkByName('default', function(err, network) {
           expect(err).to.not.exist;
           expect(network).to.exist;
+          expect(network._parent).to.exist;
           test.network = network;
           done();
         });
@@ -192,6 +197,7 @@ describe('Network', function() {
         test.hypervisor.lookupNetworkByUUID(uuid, function(err, network) {
           expect(err).to.not.exist;
           expect(network).to.exist;
+          expect(network._parent).to.exist;
 
           network.getName(function(err, name) {
             expect(err).to.not.exist;
@@ -208,10 +214,12 @@ describe('Network', function() {
       test.hypervisor.defineNetwork(xml, function(err, network) {
         expect(err).to.not.exist;
         expect(network).to.exist;
+        expect(network._parent).to.exist;
 
         test.hypervisor.lookupNetworkByName('test', function(err, network) {
           expect(err).to.not.exist;
           expect(network).to.exist;
+          expect(network._parent).to.exist;
 
           network.destroy(function(err, result) {
             expect(err).to.not.exist;

--- a/test/storage_pool.test.js
+++ b/test/storage_pool.test.js
@@ -59,6 +59,7 @@ describe('Storage Pool', function() {
       test.hypervisor.lookupStoragePoolByName('default-pool', function(err, pool) {
         expect(err).to.not.exist;
         expect(pool).to.exist;
+        expect(pool._parent).to.exist;
 
         pool.getVolumes(function(err, volumes) {
           expect(err).to.not.exist;
@@ -77,6 +78,9 @@ describe('Storage Pool', function() {
         expect(err).to.not.exist;
         test.hypervisor.lookupStoragePoolByName('default-pool', function(err, pool) {
           expect(err).to.not.exist;
+          expect(pool).to.exist;
+          expect(pool._parent).to.exist;
+
           test.pool = pool;
 
           test.pool.isActive(function(err, active) {
@@ -156,6 +160,8 @@ describe('Storage Pool', function() {
 
         test.hypervisor.lookupStoragePoolByUUID(uuid, function(err, pool) {
           expect(err).to.not.exist;
+          expect(pool).to.exist;
+          expect(pool._parent).to.exist;
 
           pool.getName(function(err, name) {
             expect(err).to.not.exist;
@@ -180,6 +186,8 @@ describe('Storage Pool', function() {
 
         test.hypervisor.lookupStoragePoolByUUID(uuid, function(err, pool) {
           expect(err).to.not.exist;
+          expect(pool).to.exist;
+          expect(pool._parent).to.exist;
 
           pool.getUUID(function(err, lookupUUID) {
             expect(err).to.not.exist;

--- a/test/storage_volume.test.js
+++ b/test/storage_volume.test.js
@@ -21,6 +21,7 @@ describe('Storage Volume', function() {
         test.hypervisor.lookupStoragePoolByName('default-pool', function(err, pool) {
           expect(err).to.not.exist;
           expect(pool).to.exist;
+          expect(pool._parent).to.exist;
           test.pool = pool;
 
           test.pool.isActive(function(err, active) {
@@ -51,6 +52,7 @@ describe('Storage Volume', function() {
         if (!!err) { console.log('\n\n\nERROR:\n'); console.log(err); console.log('\n\n\n'); }
 
         expect(err).to.not.exist;
+        expect(volume._parent).to.exist;
 
         volume.getName(function(err, name) {
           expect(err).to.not.exist;
@@ -79,6 +81,7 @@ describe('Storage Volume', function() {
           test.pool.cloneVolume(volume, clone_xml, function(err, cloneVolume) {
             expect(err).to.not.exist;
             expect(volume).to.exist;
+            expect(volume._parent).to.exist;
 
             cloneVolume.getName(function(err, name) {
               expect(err).to.not.exist;
@@ -110,13 +113,14 @@ describe('Storage Volume', function() {
         test.hypervisor.lookupStoragePoolByName('default-pool', function(err, pool) {
           expect(err).to.not.exist;
           expect(pool).to.exist;
-
+          expect(pool._parent).to.exist;
           test.pool = pool;
 
           var xml = fixture('storage_volume.xml');
           test.pool.createVolume(xml, function(err, volume) {
             expect(err).to.not.exist;
             expect(volume).to.exist;
+            expect(volume._parent).to.exist;
             test.volume = volume;
             done();
           });
@@ -214,6 +218,8 @@ describe('Storage Volume', function() {
         expect(err).to.not.exist;
         test.hypervisor.lookupStorageVolumeByKey(key, function(err, volume) {
           expect(err).to.not.exist;
+          expect(volume).to.exist;
+          expect(volume._parent).to.exist;
 
           volume.getName(function(err, lookupName) {
             expect(err).to.not.exist;
@@ -233,6 +239,8 @@ describe('Storage Volume', function() {
         expect(err).to.not.exist;
         test.pool.lookupStorageVolumeByName(name, function(err, volume) {
           expect(err).to.not.exist;
+          expect(volume).to.exist;
+          expect(volume._parent).to.exist;
 
           volume.getKey(function(err, lookupKey) {
             expect(err).to.not.exist;
@@ -252,6 +260,8 @@ describe('Storage Volume', function() {
         expect(err).to.not.exist;
         test.hypervisor.lookupStorageVolumeByPath(path, function(err, volume) {
           expect(err).to.not.exist;
+          expect(volume).to.exist;
+          expect(volume._parent).to.exist;
 
           volume.getKey(function(err, lookupKey) {
             expect(err).to.not.exist;


### PR DESCRIPTION
Previously it was possible for a parent to go out of scope once a child was looked up from the hypervisor. This change adds a _parent reference to all children that have parents

closes #65