### PR TITLE
Keep a copy of the error object info as it will be referenced later

### DIFF
--- a/src/domain.cc
+++ b/src/domain.cc
@@ -271,7 +271,7 @@ NLV_WORKER_EXECUTE(Domain, LookupById)
   NLV_WORKER_ASSERT_PARENT_HANDLE();
   lookupHandle_ = virDomainLookupByID(parent_->handle_, id_);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -283,7 +283,7 @@ NLV_WORKER_EXECUTE(Domain, Create)
   unsigned int flags = 0;
   lookupHandle_ = virDomainCreateXML(parent_->handle_, value_.c_str(), flags);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -294,7 +294,7 @@ NLV_WORKER_EXECUTE(Domain, Define)
   NLV_WORKER_ASSERT_PARENT_HANDLE();
   lookupHandle_ = virDomainDefineXML(parent_->handle_, value_.c_str());
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -320,7 +320,7 @@ NLV_WORKER_EXECUTE(Domain, Save)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainSave(Handle(), path_.c_str());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -354,7 +354,7 @@ NLV_WORKER_EXECUTE(Domain, Restore)
   NLV_WORKER_ASSERT_CONNECTION();
   int result = virDomainRestore(Handle(), path_.c_str());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -383,7 +383,7 @@ NLV_WORKER_EXECUTE(Domain, CoreDump)
   unsigned int flags = 0;
   int result = virDomainCoreDump(Handle(), path_.c_str(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -396,7 +396,7 @@ NLV_WORKER_EXECUTE(Domain, Undefine)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainUndefine(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -409,7 +409,7 @@ NLV_WORKER_EXECUTE(Domain, Destroy)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainDestroy(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -423,7 +423,7 @@ NLV_WORKER_EXECUTE(Domain, ManagedSave)
   unsigned int flags = 0;
   int result = virDomainManagedSave(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -437,7 +437,7 @@ NLV_WORKER_EXECUTE(Domain, ManagedSaveRemove)
   unsigned int flags = 0;
   int result = virDomainManagedSaveRemove(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -450,7 +450,7 @@ NLV_WORKER_EXECUTE(Domain, GetName)
   NLV_WORKER_ASSERT_DOMAIN();
   const char *result = virDomainGetName(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -464,7 +464,7 @@ NLV_WORKER_EXECUTE(Domain, GetId)
   unsigned int result = virDomainGetID(Handle());
   if (result == -1u) {
     data_ = -1;
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -477,7 +477,7 @@ NLV_WORKER_EXECUTE(Domain, GetOSType)
   NLV_WORKER_ASSERT_DOMAIN();
   const char *result = virDomainGetOSType(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -491,7 +491,7 @@ NLV_WORKER_EXECUTE(Domain, GetUUID)
   char *uuid = new char[VIR_UUID_STRING_BUFLEN];
   int result = virDomainGetUUIDString(Handle(), uuid);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     delete[] uuid;
     return;
   }
@@ -507,7 +507,7 @@ NLV_WORKER_EXECUTE(Domain, GetAutostart)
   int autostart;
   int result = virDomainGetAutostart(Handle(), &autostart);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -520,7 +520,7 @@ NLV_WORKER_EXECUTE(Domain, GetMaxMemory)
   NLV_WORKER_ASSERT_DOMAIN();
   unsigned long result = virDomainGetMaxMemory(Handle());
   if (result == 0) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -533,7 +533,7 @@ NLV_WORKER_EXECUTE(Domain, GetMaxVcpus)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainGetMaxVcpus(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -546,7 +546,7 @@ NLV_WORKER_EXECUTE(Domain, IsActive)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainIsActive(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -559,7 +559,7 @@ NLV_WORKER_EXECUTE(Domain, IsPersistent)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainIsPersistent(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -572,7 +572,7 @@ NLV_WORKER_EXECUTE(Domain, IsUpdated)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainIsUpdated(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -586,7 +586,7 @@ NLV_WORKER_EXECUTE(Domain, Start)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainCreate(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -600,7 +600,7 @@ NLV_WORKER_EXECUTE(Domain, Reboot)
   unsigned long flags = 0;
   int result = virDomainReboot(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -614,7 +614,7 @@ NLV_WORKER_EXECUTE(Domain, Reset)
   unsigned long flags = 0;
   int result = virDomainReset(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -627,7 +627,7 @@ NLV_WORKER_EXECUTE(Domain, Shutdown)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainShutdown(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -640,7 +640,7 @@ NLV_WORKER_EXECUTE(Domain, Suspend)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainSuspend(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -653,7 +653,7 @@ NLV_WORKER_EXECUTE(Domain, Resume)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainResume(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -667,7 +667,7 @@ NLV_WORKER_EXECUTE(Domain, HasManagedSaveImage)
   unsigned long flags = 0;
   int result = virDomainHasManagedSaveImage(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -695,7 +695,7 @@ NLV_WORKER_EXECUTE(Domain, SetAutostart)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainSetAutostart(Handle(), autoStart_ ? 1 : 0);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -724,7 +724,7 @@ NLV_WORKER_EXECUTE(Domain, SetMaxMemory)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainSetMaxMemory(Handle(), maxMemory_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -753,7 +753,7 @@ NLV_WORKER_EXECUTE(Domain, SetMemory)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainSetMemory(Handle(), memory_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -785,7 +785,7 @@ NLV_WORKER_EXECUTE(Domain, ToXml)
   NLV_WORKER_ASSERT_DOMAIN();
   char *result = virDomainGetXMLDesc(Handle(), flags_);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -834,12 +834,13 @@ NLV_WORKER_EXECUTE(Domain, GetMetadata)
 	  ? namespace_uri_.c_str() : NULL;
   char *result = virDomainGetMetadata(Handle(), type_, namespace_uri, flags_);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+      SetVirError(virSaveLastError());
     return;
   }
 
   data_ = result;
   free(result);
+
 }
 #endif
 
@@ -899,7 +900,7 @@ NLV_WORKER_EXECUTE(Domain, SetMetadata)
 	  ? namespace_uri_.c_str() : NULL;
   int result = virDomainSetMetadata(Handle(), type_, metadata, namespace_key, namespace_uri, flags_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -913,7 +914,7 @@ NLV_WORKER_EXECUTE(Domain, GetInfo)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainGetInfo(Handle(), &info_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -972,7 +973,7 @@ NLV_WORKER_EXECUTE(Domain, GetBlockInfo)
   unsigned int flags = 0;
   int result = virDomainGetBlockInfo(Handle(), path_.c_str(), &info_, flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -1011,7 +1012,7 @@ NLV_WORKER_EXECUTE(Domain, GetBlockStats)
   int result =
     virDomainBlockStats(Handle(), path_.c_str(), &stats_, sizeof(stats_));
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -1036,7 +1037,7 @@ NLV_WORKER_EXECUTE(Domain, GetSchedulerType)
   NLV_WORKER_ASSERT_DOMAIN();
   char *result = virDomainGetSchedulerType(Handle(), NULL);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1052,7 +1053,7 @@ NLV_WORKER_EXECUTE(Domain, GetSchedulerParameters)
   int numParams;
   char *type = virDomainGetSchedulerType(Handle(), &numParams);
   if (type == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
   free(type);
@@ -1060,7 +1061,7 @@ NLV_WORKER_EXECUTE(Domain, GetSchedulerParameters)
   params_.resize(numParams);
   int result = virDomainGetSchedulerParameters(Handle(), params_.data(), &numParams);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -1071,7 +1072,7 @@ NLV_WORKER_EXECUTE(Domain, GetSecurityLabel)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainGetSecurityLabel(Handle(), &info_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -1109,7 +1110,7 @@ NLV_WORKER_EXECUTE(Domain, GetInterfaceStats)
   int result =
     virDomainInterfaceStats(Handle(), interface_.c_str(), &stats_, sizeof(stats_));
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -1143,7 +1144,7 @@ NLV_WORKER_EXECUTE(Domain, GetJobInfo)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainGetJobInfo(Handle(), &info_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -1200,7 +1201,7 @@ NLV_WORKER_EXECUTE(Domain, AbortCurrentJob)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainAbortJob(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1215,7 +1216,7 @@ NLV_WORKER_EXECUTE(Domain, GetMemoryStats)
   stats_.resize(VIR_DOMAIN_MEMORY_STAT_NR);
   int result = virDomainMemoryStats(Handle(), stats_.data(), stats_.size(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -1290,7 +1291,7 @@ NLV_WORKER_EXECUTE(Domain, AttachDevice)
   }
 
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1336,7 +1337,7 @@ NLV_WORKER_EXECUTE(Domain, DetachDevice)
   }
 
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1376,7 +1377,7 @@ NLV_WORKER_EXECUTE(Domain, UpdateDevice)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainUpdateDeviceFlags(Handle(), xml_.c_str(), flags_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1390,13 +1391,13 @@ NLV_WORKER_EXECUTE(Domain, GetVcpus)
   virDomainInfo info;
   int result = virDomainGetInfo(Handle(), &info);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
   result = virNodeGetInfo(virDomainGetConnect(Handle()), &nodeInfo_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1406,7 +1407,7 @@ NLV_WORKER_EXECUTE(Domain, GetVcpus)
   result =
     virDomainGetVcpus(Handle(), info_.data(), info_.size(), map_.data(), map_.size());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -1471,7 +1472,7 @@ NLV_WORKER_EXECUTE(Domain, SetVcpus)
   NLV_WORKER_ASSERT_DOMAIN();
   int result = virDomainSetVcpus(Handle(), count_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1506,7 +1507,7 @@ NLV_WORKER_EXECUTE(Domain, SendKeys)
   int result =
     virDomainSendKey(Handle(), 0, 150, keys_.data(), keys_.size(), 0);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1577,14 +1578,14 @@ NLV_WORKER_EXECUTE(Domain, Migrate)
   if(conn_) {
     migrated_ = virDomainMigrate(Handle(), conn_, flags_, destname_.c_str(), uri_.c_str(), bandwidth_);
     if(migrated_ == NULL) {
-      SetVirError(virGetLastError());
+      SetVirError(virSaveLastError());
       return;
     }
   } else {
     int ret = -1;
     ret = virDomainMigrateToURI(Handle(), uri_.c_str(), flags_, destname_.c_str(), bandwidth_);
     if(ret == -1) {
-      SetVirError(virGetLastError());
+      SetVirError(virSaveLastError());
       return;
     }
   }
@@ -1642,7 +1643,7 @@ NLV_WORKER_EXECUTE(Domain, PinVcpu)
   int cpumaplen;
 
   if(virNodeGetInfo(virDomainGetConnect(Handle()), &nodeinfo) == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1662,7 +1663,7 @@ NLV_WORKER_EXECUTE(Domain, PinVcpu)
   }
 
   if(virDomainPinVcpu(Handle(), vcpu_, cpumap.data(), cpumaplen) == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1699,7 +1700,7 @@ NAN_METHOD(Domain::MemoryPeek)
 NLV_WORKER_EXECUTE(Domain, MemoryPeek)
 {
   if(virDomainMemoryPeek(Handle(), start_, size_ , buffer_.data(), flags_) == -1)
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
 }
 
 NLV_WORKER_OKCALLBACK(Domain, MemoryPeek)
@@ -1741,7 +1742,7 @@ NAN_METHOD(Domain::BlockPeek)
 NLV_WORKER_EXECUTE(Domain, BlockPeek)
 {
   if(virDomainBlockPeek(Handle(), path_.c_str(), start_, size_ , buffer_.data(), flags_) == -1)
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
 }
 
 NLV_WORKER_OKCALLBACK(Domain, BlockPeek)
@@ -1760,7 +1761,7 @@ NLV_WORKER_EXECUTE(Domain, HasCurrentSnapshot)
   ret = virDomainHasCurrentSnapshot(Handle(), flags);
 
   if (ret == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1790,13 +1791,13 @@ NLV_WORKER_EXECUTE(Domain, RevertToSnapshot)
 
   snapshot = virDomainSnapshotLookupByName(Handle(), name_.c_str(), flags);
   if(snapshot == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
   ret = virDomainRevertToSnapshot(snapshot, flags);
   if(ret == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1830,7 +1831,7 @@ NLV_WORKER_EXECUTE(Domain, TakeSnapshot)
   virDomainSnapshotPtr snapshot = NULL;
   snapshot = virDomainSnapshotCreateXML(Handle(), xml_.c_str(), flags_);
   if(snapshot == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1860,12 +1861,12 @@ NLV_WORKER_EXECUTE(Domain, DeleteSnapshot)
 
   snapshot = virDomainSnapshotLookupByName(Handle(), name_.c_str(), flags);
   if(snapshot == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
   if(virDomainSnapshotDelete(snapshot, flags) == -1)
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
 
   virDomainSnapshotFree(snapshot);
 }
@@ -1893,14 +1894,14 @@ NLV_WORKER_EXECUTE(Domain, LookupSnapshotByName)
 
   snapshot = virDomainSnapshotLookupByName(Handle(), name_.c_str(), flags);
   if(snapshot == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
   xml = virDomainSnapshotGetXMLDesc(snapshot, flags);
   virDomainSnapshotFree(snapshot);
   if(xml == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1917,14 +1918,14 @@ NLV_WORKER_EXECUTE(Domain, GetCurrentSnapshot)
 
   snapshot = virDomainSnapshotCurrent(Handle(), flags);
   if(snapshot == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
   xml = virDomainSnapshotGetXMLDesc(snapshot, flags);
   virDomainSnapshotFree(snapshot);
   if(xml == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1951,7 +1952,7 @@ NAN_METHOD(Domain::SetMigrationMaxDowntime) {
 NLV_WORKER_EXECUTE(Domain, SetMigrationMaxDowntime)
 {
   if(virDomainMigrateSetMaxDowntime(Handle(), downtime_, flags_) == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -1967,13 +1968,13 @@ NLV_WORKER_EXECUTE(Domain, GetSnapshots)
 
   num_snapshots = virDomainSnapshotNum(Handle(), flags);
   if(num_snapshots == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
   std::vector<char*> names(num_snapshots);
   if(virDomainSnapshotListNames(Handle(), names.data(), num_snapshots, flags) == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -2059,7 +2060,7 @@ NLV_WORKER_EXECUTE(Domain, RegisterEvent)
   );
 
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -2087,7 +2088,7 @@ NAN_METHOD(Domain::UnregisterEvent)
 NLV_WORKER_EXECUTE(Domain, UnregisterEvent)
 {
   if (virConnectDomainEventDeregisterAny(virDomainGetConnect(Handle()), callbackId_) == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -2117,7 +2118,7 @@ NAN_METHOD(Domain::SetSchedulerParameters)
 
   type = virDomainGetSchedulerType(domain->handle_, &nparams);
   if (type == NULL) {
-    Nan::ThrowError(Error::New(virGetLastError()));
+    Nan::ThrowError(Error::New(virSaveLastError()));
     return info.GetReturnValue().Set(Nan::False());
   }
   free(type);
@@ -2132,7 +2133,7 @@ NAN_METHOD(Domain::SetSchedulerParameters)
 
   ret = virDomainGetSchedulerParameters(domain->handle_, params, &nparams);
   if(ret == -1) {
-    Nan::ThrowError(Error::New(virGetLastError()));
+    Nan::ThrowError(Error::New(virSaveLastError()));
     free(params);
     return info.GetReturnValue().Set(Nan::False());
   }
@@ -2169,7 +2170,7 @@ NAN_METHOD(Domain::SetSchedulerParameters)
 
   ret = virDomainSetSchedulerParameters(domain->handle_, params, nparams);
   if (ret == -1) {
-    Nan::ThrowError(Error::New(virGetLastError()));
+    Nan::ThrowError(Error::New(virSaveLastError()));
     free(params);
     return info.GetReturnValue().Set(Nan::False());
   }

--- a/src/error.cc
+++ b/src/error.cc
@@ -153,6 +153,11 @@ Error::Error(virErrorPtr error)
   error_ = error;
 }
 
+Error::~Error()
+{
+  virFreeError(error_);
+}
+
 Local<Value> Error::New(virErrorPtr error)
 {
   Nan::EscapableHandleScope scope;

--- a/src/error.cc
+++ b/src/error.cc
@@ -176,7 +176,7 @@ NAN_GETTER(Error::Getter)
   } else if (property->Equals(Nan::New("domain").ToLocalChecked())) {
     return info.GetReturnValue().Set(Nan::New(error_->domain));
   } else if (property->Equals(Nan::New("message").ToLocalChecked())) {
-    return info.GetReturnValue().Set(Nan::New(error_->message).ToLocalChecked());
+    return info.GetReturnValue().Set(Nan::New(error_->message != NULL ? error_->message : "unknown error").ToLocalChecked());
   } else if (property->Equals(Nan::New("level").ToLocalChecked())) {
     return info.GetReturnValue().Set(Nan::New(error_->level));
   } else if (property->Equals(Nan::New("str1").ToLocalChecked())) {

--- a/src/error.h
+++ b/src/error.h
@@ -14,6 +14,7 @@ public:
 
 private:
   explicit Error(virErrorPtr error);
+  ~Error();
   static Nan::Persistent<Function> constructor;
 
   static NAN_GETTER(Getter);

--- a/src/hypervisor.cc
+++ b/src/hypervisor.cc
@@ -286,7 +286,7 @@ NLV_WORKER_EXECUTE(Hypervisor, Connect)
     virConnectOpenAuth((const char*) hypervisor_->uri_.c_str(), &auth,
                        hypervisor_->readOnly_ ? VIR_CONNECT_RO : 0);
   if (hypervisor_->handle_ == NULL)
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
 }
 
 NAN_METHOD(Hypervisor::Disconnect)
@@ -310,7 +310,7 @@ NLV_WORKER_EXECUTE(Hypervisor, Disconnect)
   hypervisor_->ClearHandle();
   // int result = virConnectClose(Handle());
   // if (result == -1) {
-  //   SetVirError(virGetLastError());
+  //   SetVirError(virSaveLastError());
   //   return;
   // }
 
@@ -323,7 +323,7 @@ NLV_WORKER_EXECUTE(Hypervisor, Disconnect)
     NLV_WORKER_ASSERT_CONNECTION(); \
     char *result = Accessor(Handle()); \
     if (result == NULL) { \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       return; \
     } \
     data_ = result; \
@@ -335,7 +335,7 @@ NLV_WORKER_EXECUTE(Hypervisor, Disconnect)
     NLV_WORKER_ASSERT_CONNECTION(); \
     const char *result = Accessor(Handle()); \
     if (result == NULL) { \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       return; \
     } \
     data_ = result; \
@@ -354,7 +354,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetSysInfo)
   NLV_WORKER_ASSERT_CONNECTION();
   char *result = virConnectGetSysinfo(Handle(), 0);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -376,7 +376,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetVersion)
   unsigned long version;
   int result = virConnectGetVersion(Handle(), &version);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   } else if (result == 0 && version == 0) {
     return;
@@ -400,7 +400,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetLibVirtVersion)
   unsigned long version;
   int result = virConnectGetLibVersion(Handle(), &version);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -418,7 +418,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetLibVirtVersion)
     NLV_WORKER_ASSERT_CONNECTION(); \
     int result = Accessor(Handle());  \
     if (result == -1) { \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       return; \
     } \
     data_ = result;  \
@@ -464,7 +464,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetMaxVcpus)
   NLV_WORKER_ASSERT_CONNECTION();
   int result = virConnectGetMaxVcpus(Handle(), type_.c_str());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -510,7 +510,7 @@ NLV_WORKER_EXECUTE(Hypervisor, SetKeepAlive)
 
   int result = virConnectSetKeepAlive(Handle(), interval_, count_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -554,7 +554,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetBaselineCPU)
   delete [] cpus_;
 
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -584,7 +584,7 @@ NLV_WORKER_EXECUTE(Hypervisor, CompareCPU)
   NLV_WORKER_ASSERT_CONNECTION();
   int result = virConnectCompareCPU(Handle(), (const char *)cpu_.c_str(), flags_);
   if (result == VIR_CPU_COMPARE_ERROR) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -596,7 +596,7 @@ NLV_WORKER_EXECUTE(Hypervisor, CompareCPU)
     NLV_WORKER_ASSERT_CONNECTION()  \
     int count = CountMethod(Handle());  \
     if (count == -1) {  \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       return; \
     } \
     char **names = new char*[count]; \
@@ -606,7 +606,7 @@ NLV_WORKER_EXECUTE(Hypervisor, CompareCPU)
     } \
     int nameCount = ListMethod(Handle(), names, count); \
     if (nameCount == -1) {  \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       delete [] names; \
       return; \
     } \
@@ -622,7 +622,7 @@ NLV_WORKER_EXECUTE(Hypervisor, CompareCPU)
     NLV_WORKER_ASSERT_CONNECTION()  \
     int count = CountMethod(Handle());  \
     if (count == -1) {  \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       return; \
     } \
     int *elements = new int[count]; \
@@ -633,7 +633,7 @@ NLV_WORKER_EXECUTE(Hypervisor, CompareCPU)
     } \
     int elementCount = ListMethod(Handle(), elements, count); \
     if (elementCount == -1) {  \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       return; \
     } \
     for (int i = 0; i < elementCount; ++i) { \
@@ -744,7 +744,7 @@ NLV_WORKER_EXECUTE(Hypervisor, ListNodeDevices)
     virNodeNumOfDevices(Handle(), (const char *) capability_.c_str(), flags);
 
   if (num_devices == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -758,7 +758,7 @@ NLV_WORKER_EXECUTE(Hypervisor, ListNodeDevices)
     virNodeListDevices(Handle(), (const char *)capability_.c_str(), names, num_devices, flags);
   if (num_devices == -1) {
     free(names);
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -776,7 +776,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetNodeSecurityModel)
   NLV_WORKER_ASSERT_CONNECTION();
   int result = virNodeGetSecurityModel(Handle(), &securityModel_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -803,7 +803,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetNodeInfo)
   NLV_WORKER_ASSERT_CONNECTION();
   int result = virNodeGetInfo(Handle(), &info_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -832,7 +832,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetNodeFreeMemory)
   NLV_WORKER_ASSERT_CONNECTION();
   unsigned long long result = virNodeGetFreeMemory(Handle());
   if (result == 0) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -865,7 +865,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetNodeMemoryStats)
       result = virNodeGetMemoryStats(Handle(), cellNum_, &info_[0], &nparams, flags_);
   }
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -918,7 +918,7 @@ NLV_WORKER_EXECUTE(Hypervisor, GetNodeCellsFreeMemory)
     virNodeGetCellsFreeMemory(Handle(), results, startCell_, maxCells_);
   if (cells == -1) {
     free(results);
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 

--- a/src/interface.cc
+++ b/src/interface.cc
@@ -48,7 +48,7 @@ NLV_WORKER_EXECUTE(Interface, Start)
   unsigned int flags = 0;
   int result = virInterfaceCreate(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -63,7 +63,7 @@ NLV_WORKER_EXECUTE(Interface, Stop)
   unsigned int flags = 0;
   int result = virInterfaceDestroy(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -76,7 +76,7 @@ NLV_WORKER_EXECUTE(Interface, Define)
   unsigned int flags = 0;
   lookupHandle_ = virInterfaceDefineXML(parent_->handle_, value_.c_str(), flags);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -87,7 +87,7 @@ NLV_WORKER_EXECUTE(Interface, Undefine)
   NLV_WORKER_ASSERT_INTERFACE();
   int result = virInterfaceUndefine(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -146,7 +146,7 @@ NLV_WORKER_EXECUTE(Interface, GetName)
   NLV_WORKER_ASSERT_INTERFACE();
   const char *result = virInterfaceGetName(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -159,7 +159,7 @@ NLV_WORKER_EXECUTE(Interface, GetMacAddress)
   NLV_WORKER_ASSERT_INTERFACE();
   const char *result = virInterfaceGetMACString(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -172,7 +172,7 @@ NLV_WORKER_EXECUTE(Interface, IsActive)
   NLV_WORKER_ASSERT_INTERFACE();
   int result = virInterfaceIsActive(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -186,7 +186,7 @@ NLV_WORKER_EXECUTE(Interface, ToXml)
   unsigned int flags = 0;
   char *result = virInterfaceGetXMLDesc(Handle(), flags);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 

--- a/src/network.cc
+++ b/src/network.cc
@@ -90,7 +90,7 @@ NLV_WORKER_EXECUTE(Network, Create)
   NLV_WORKER_ASSERT_PARENT_HANDLE();
   lookupHandle_ = virNetworkCreateXML(parent_->handle_, value_.c_str());
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -101,7 +101,7 @@ NLV_WORKER_EXECUTE(Network, Define)
   NLV_WORKER_ASSERT_PARENT_HANDLE();
   lookupHandle_ = virNetworkDefineXML(parent_->handle_, value_.c_str());
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -112,7 +112,7 @@ NLV_WORKER_EXECUTE(Network, Start)
   NLV_WORKER_ASSERT_NETWORK();
   int result = virNetworkCreate(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -125,7 +125,7 @@ NLV_WORKER_EXECUTE(Network, GetName)
   NLV_WORKER_ASSERT_NETWORK();
   const char *result = virNetworkGetName(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -139,7 +139,7 @@ NLV_WORKER_EXECUTE(Network, GetUUID)
   char *uuid = new char[VIR_UUID_STRING_BUFLEN];
   int result = virNetworkGetUUIDString(Handle(), uuid);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     delete[] uuid;
     return;
   }
@@ -155,7 +155,7 @@ NLV_WORKER_EXECUTE(Network, GetAutostart)
   int autostart;
   int result = virNetworkGetAutostart(Handle(), &autostart);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -183,7 +183,7 @@ NLV_WORKER_EXECUTE(Network, SetAutostart)
   NLV_WORKER_ASSERT_NETWORK();
   int result = virNetworkSetAutostart(Handle(), autoStart_ ? 1 : 0);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -196,7 +196,7 @@ NLV_WORKER_EXECUTE(Network, IsActive)
   NLV_WORKER_ASSERT_NETWORK();
   int result = virNetworkIsActive(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -209,7 +209,7 @@ NLV_WORKER_EXECUTE(Network, IsPersistent)
   NLV_WORKER_ASSERT_NETWORK();
   int result = virNetworkIsPersistent(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -222,7 +222,7 @@ NLV_WORKER_EXECUTE(Network, Undefine)
   NLV_WORKER_ASSERT_NETWORK();
   int result = virNetworkUndefine(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -235,7 +235,7 @@ NLV_WORKER_EXECUTE(Network, Destroy)
   NLV_WORKER_ASSERT_NETWORK();
   int result = virNetworkDestroy(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -249,7 +249,7 @@ NLV_WORKER_EXECUTE(Network, ToXml)
   unsigned int flags = 0;
   char *result = virNetworkGetXMLDesc(Handle(), flags);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -263,7 +263,7 @@ NLV_WORKER_EXECUTE(Network, GetBridgeName)
   NLV_WORKER_ASSERT_NETWORK();
   const char *result = virNetworkGetBridgeName(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 

--- a/src/network_filter.cc
+++ b/src/network_filter.cc
@@ -85,7 +85,7 @@ NLV_WORKER_EXECUTE(NetworkFilter, Define)
   NLV_WORKER_ASSERT_PARENT_HANDLE();
   lookupHandle_ = virNWFilterDefineXML(parent_->handle_, value_.c_str());
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -96,7 +96,7 @@ NLV_WORKER_EXECUTE(NetworkFilter, GetName)
   NLV_WORKER_ASSERT_INTERFACE();
   const char *result = virNWFilterGetName(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -110,7 +110,7 @@ NLV_WORKER_EXECUTE(NetworkFilter, GetUUID)
   char *uuid = new char[VIR_UUID_STRING_BUFLEN];
   int result = virNWFilterGetUUIDString(Handle(), uuid);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     delete[] uuid;
     return;
   }
@@ -125,7 +125,7 @@ NLV_WORKER_EXECUTE(NetworkFilter, Undefine)
   NLV_WORKER_ASSERT_INTERFACE();
   int result = virNWFilterUndefine(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -139,7 +139,7 @@ NLV_WORKER_EXECUTE(NetworkFilter, ToXml)
   unsigned int flags = 0;
   char *result = virNWFilterGetXMLDesc(Handle(), flags);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 

--- a/src/nlv_async_worker.h
+++ b/src/nlv_async_worker.h
@@ -17,6 +17,7 @@ class NLVAsyncWorkerBase : public Nan::AsyncWorker
 {
 public:
   explicit NLVAsyncWorkerBase(Nan::Callback *callback);
+  ~NLVAsyncWorkerBase();
 
   virErrorPtr VirError() const;
   void SetVirError(virErrorPtr error);
@@ -267,7 +268,7 @@ protected:
   NLV_WORKER_EXECUTE(Class, Method) { \
     lookupHandle_ = Accessor(parent_->handle_, value_.c_str());  \
     if (lookupHandle_ == NULL) { \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       return; \
     } \
   }

--- a/src/node_device.cc
+++ b/src/node_device.cc
@@ -89,7 +89,7 @@ NLV_WORKER_EXECUTE(NodeDevice, Create)
   unsigned int flags = 0;
   lookupHandle_ = virNodeDeviceCreateXML(parent_->handle_, value_.c_str(), flags);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -100,7 +100,7 @@ NLV_WORKER_EXECUTE(NodeDevice, Destroy)
   NLV_WORKER_ASSERT_NODEDEVICE();
   int result = virNodeDeviceDestroy(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -113,7 +113,7 @@ NLV_WORKER_EXECUTE(NodeDevice, Detach)
   NLV_WORKER_ASSERT_NODEDEVICE();
   int result = virNodeDeviceDettach(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -126,7 +126,7 @@ NLV_WORKER_EXECUTE(NodeDevice, Reattach)
   NLV_WORKER_ASSERT_NODEDEVICE();
   int result = virNodeDeviceReAttach(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -139,7 +139,7 @@ NLV_WORKER_EXECUTE(NodeDevice, Reset)
   NLV_WORKER_ASSERT_NODEDEVICE();
   int result = virNodeDeviceReset(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -152,7 +152,7 @@ NLV_WORKER_EXECUTE(NodeDevice, GetName)
   NLV_WORKER_ASSERT_NODEDEVICE();
   const char *result = virNodeDeviceGetName(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -165,7 +165,7 @@ NLV_WORKER_EXECUTE(NodeDevice, GetParentName)
   NLV_WORKER_ASSERT_NODEDEVICE();
   const char *result = virNodeDeviceGetParent(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -179,7 +179,7 @@ NLV_WORKER_EXECUTE(NodeDevice, ToXml)
   unsigned int flags = 0;
   char *result = virNodeDeviceGetXMLDesc(Handle(), flags);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -195,7 +195,7 @@ NLV_WORKER_EXECUTE(NodeDevice, GetCapabilities)
   Nan::HandleScope scope;
   int num_caps = virNodeDeviceNumOfCaps(Handle());
   if (num_caps == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -208,7 +208,7 @@ NLV_WORKER_EXECUTE(NodeDevice, GetCapabilities)
   num_caps = virNodeDeviceListCaps(Handle(), names, num_caps);
   if (num_caps == -1) {
     free(names);
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 

--- a/src/secret.cc
+++ b/src/secret.cc
@@ -43,7 +43,7 @@ NLV_WORKER_EXECUTE(Secret, Define)
   unsigned int flags = 0;
   lookupHandle_ = virSecretDefineXML(parent_->handle_, value_.c_str(), flags);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -54,7 +54,7 @@ NLV_WORKER_EXECUTE(Secret, Undefine)
   NLV_WORKER_ASSERT_SECRET();
   int result = virSecretUndefine(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -103,7 +103,7 @@ NLV_WORKER_EXECUTE(Secret, LookupByUsage)
   NLV_WORKER_ASSERT_PARENT_HANDLE();
   lookupHandle_ = virSecretLookupByUsage(parent_->handle_, usageType_, value_.c_str());
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -137,7 +137,7 @@ NLV_WORKER_EXECUTE(Secret, GetUUID)
   char *uuid = new char[VIR_UUID_STRING_BUFLEN];
   int result = virSecretGetUUIDString(Handle(), uuid);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     delete[] uuid;
     return;
   }
@@ -152,7 +152,7 @@ NLV_WORKER_EXECUTE(Secret, GetUsageId)
   NLV_WORKER_ASSERT_SECRET();
   const char *result = virSecretGetUsageID(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -166,7 +166,7 @@ NLV_WORKER_EXECUTE(Secret, GetUsageType)
   // int usage_type = VIR_SECRET_USAGE_TYPE_NONE;
   int result = virSecretGetUsageType(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -181,7 +181,7 @@ NLV_WORKER_EXECUTE(Secret, GetValue)
   unsigned int flags = 0;
   unsigned char *result = virSecretGetValue(Handle(), &size, flags);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -213,7 +213,7 @@ NLV_WORKER_EXECUTE(Secret, SetValue)
   int result = virSecretSetValue(Handle(),
       reinterpret_cast<const unsigned char *>(value_.c_str()), sizeof(value_.c_str()), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -227,7 +227,7 @@ NLV_WORKER_EXECUTE(Secret, ToXml)
   unsigned int flags = 0;
   char *result = virSecretGetXMLDesc(Handle(), flags);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 

--- a/src/storage_pool.cc
+++ b/src/storage_pool.cc
@@ -146,7 +146,7 @@ NLV_WORKER_EXECUTE(StoragePool, Create)
   unsigned int flags = 0;
   lookupHandle_ = virStoragePoolCreateXML(parent_->handle_, value_.c_str(), flags);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -158,7 +158,7 @@ NLV_WORKER_EXECUTE(StoragePool, Define)
   unsigned int flags = 0;
   lookupHandle_ = virStoragePoolDefineXML(parent_->handle_, value_.c_str(), flags);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -170,7 +170,7 @@ NLV_WORKER_EXECUTE(StoragePool, Build)
   unsigned int flags = 0;
   int result = virStoragePoolBuild(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -183,7 +183,7 @@ NLV_WORKER_EXECUTE(StoragePool, Undefine)
   NLV_WORKER_ASSERT_STORAGEPOOL();
   int result = virStoragePoolUndefine(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -197,7 +197,7 @@ NLV_WORKER_EXECUTE(StoragePool, Start)
   unsigned int flags = 0;
   int result = virStoragePoolCreate(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -210,7 +210,7 @@ NLV_WORKER_EXECUTE(StoragePool, Stop)
   NLV_WORKER_ASSERT_STORAGEPOOL();
   int result = virStoragePoolDestroy(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -248,7 +248,7 @@ NLV_WORKER_EXECUTE(StoragePool, Erase)
 
   int result = virStoragePoolDelete(Handle(), flags_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -262,7 +262,7 @@ NLV_WORKER_EXECUTE(StoragePool, GetAutostart)
   int autostart;
   int result = virStoragePoolGetAutostart(Handle(), &autostart);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -290,7 +290,7 @@ NLV_WORKER_EXECUTE(StoragePool, SetAutostart)
   NLV_WORKER_ASSERT_STORAGEPOOL();
   int result = virStoragePoolSetAutostart(Handle(), autoStart_ ? 1 : 0);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -303,7 +303,7 @@ NLV_WORKER_EXECUTE(StoragePool, GetInfo)
   NLV_WORKER_ASSERT_STORAGEPOOL();
   int result = virStoragePoolGetInfo(Handle(), &info_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -327,7 +327,7 @@ NLV_WORKER_EXECUTE(StoragePool, GetName)
   NLV_WORKER_ASSERT_STORAGEPOOL();
   const char *result = virStoragePoolGetName(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -341,7 +341,7 @@ NLV_WORKER_EXECUTE(StoragePool, GetUUID)
   char *uuid = new char[VIR_UUID_STRING_BUFLEN];
   int result = virStoragePoolGetUUIDString(Handle(), uuid);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     delete[] uuid;
     return;
   }
@@ -357,7 +357,7 @@ NLV_WORKER_EXECUTE(StoragePool, ToXml)
   unsigned int flags = 0;
   char *result = virStoragePoolGetXMLDesc(Handle(), flags);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -371,7 +371,7 @@ NLV_WORKER_EXECUTE(StoragePool, IsActive)
   NLV_WORKER_ASSERT_STORAGEPOOL();
   int result = virStoragePoolIsActive(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -384,7 +384,7 @@ NLV_WORKER_EXECUTE(StoragePool, IsPersistent)
   NLV_WORKER_ASSERT_STORAGEPOOL();
   int result = virStoragePoolIsPersistent(Handle());
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -410,7 +410,7 @@ NLV_WORKER_EXECUTE(StoragePool, GetVolumes)
   NLV_WORKER_ASSERT_STORAGEPOOL();
   int num_volumes = virStoragePoolNumOfVolumes(Handle());
   if (num_volumes == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -423,7 +423,7 @@ NLV_WORKER_EXECUTE(StoragePool, GetVolumes)
   num_volumes = virStoragePoolListVolumes(Handle(), volumes, num_volumes);
   if (num_volumes == -1) {
     free(volumes);
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -443,7 +443,7 @@ NLV_WORKER_EXECUTE(StoragePool, Refresh)
   unsigned int flags = 0;
   int result = virStoragePoolRefresh(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 

--- a/src/storage_volume.cc
+++ b/src/storage_volume.cc
@@ -75,7 +75,7 @@ NLV_WORKER_EXECUTE(StorageVolume, Create)
   unsigned int flags = 0;
   lookupHandle_ = virStorageVolCreateXML(parent_->handle_, value_.c_str(), flags);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -87,7 +87,7 @@ NLV_WORKER_EXECUTE(StorageVolume, Delete)
   unsigned int flags = 0;
   int result = virStorageVolDelete(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -101,7 +101,7 @@ NLV_WORKER_EXECUTE(StorageVolume, Wipe)
   unsigned int flags = 0;
   int result = virStorageVolWipe(Handle(), flags);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -127,7 +127,7 @@ NLV_WORKER_EXECUTE(StorageVolume, GetInfo)
   NLV_WORKER_ASSERT_STORAGEVOLUME();
   int result = virStorageVolGetInfo(Handle(), &info_);
   if (result == -1) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }
@@ -150,7 +150,7 @@ NLV_WORKER_EXECUTE(StorageVolume, GetKey)
   NLV_WORKER_ASSERT_STORAGEVOLUME();
   const char *result = virStorageVolGetKey(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -163,7 +163,7 @@ NLV_WORKER_EXECUTE(StorageVolume, GetName)
   NLV_WORKER_ASSERT_STORAGEVOLUME();
   const char *result = virStorageVolGetName(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -176,7 +176,7 @@ NLV_WORKER_EXECUTE(StorageVolume, GetPath)
   NLV_WORKER_ASSERT_STORAGEVOLUME();
   const char *result = virStorageVolGetPath(Handle());
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -190,7 +190,7 @@ NLV_WORKER_EXECUTE(StorageVolume, ToXml)
   unsigned int flags = 0;
   char *result = virStorageVolGetXMLDesc(Handle(), flags);
   if (result == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 
@@ -311,7 +311,7 @@ NLV_WORKER_EXECUTE(StorageVolume, Clone)
   lookupHandle_ =
     virStorageVolCreateXMLFrom(parent_->handle_, value_.c_str(), cloneHandle_, flags);
   if (lookupHandle_ == NULL) {
-    SetVirError(virGetLastError());
+    SetVirError(virSaveLastError());
     return;
   }
 }

--- a/src/worker_macros.h
+++ b/src/worker_macros.h
@@ -99,7 +99,7 @@
     NLV_WORKER_ASSERT_CONNECTION(); \
     int result = Accessor(Handle());  \
     if (result == -1) { \
-      SetVirError(virGetLastError()); \
+      SetVirError(virSaveLastError()); \
       return; \
     } \
     data_ = static_cast<bool>(result);  \


### PR DESCRIPTION
This fixes issue #67. 

Instead of using virGetLastError(), which returns a pointer to a thread-local error structure which gets re-used, we use virSaveLastError() which returns a private copy of the error structure.

There are two "quirks" involved.

1) Now that we have to free the structure ourselves, the fact that the reference gets handed off from the NLVAsyncWorkerBase instance to the Error instance at some point means that both classes have to be responsible for knowing which will do the actual cleanup. Don't double free, and don't never free.

2) While virGetLastError() returns NULL if there is no actual error, virSaveLastError() will always return something, so we need an additional check to see if the something is really nothing.
