### PR TITLE
Make all libvirt errors inherit from Error class LibvirtError.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,6 +19,7 @@
         'src/storage_volume.cc',
         'src/worker.cc'
       ],
+      "cflags": ["-std=c++11"],
       'include_dirs' : [
         "<!(node -e \"require('nan')\")"
       ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,7 @@
         'src/secret.cc',
         'src/storage_pool.cc',
         'src/storage_volume.cc',
+        'src/worker.cc'
       ],
       'include_dirs' : [
         "<!(node -e \"require('nan')\")"

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,15 +11,41 @@ function inherits(target, source) {
     }
 }
 
-Promise.promisifyAll(libvirt.Hypervisor.prototype);
-Promise.promisifyAll(libvirt.Domain.prototype);
-Promise.promisifyAll(libvirt.NodeDevice.prototype);
-Promise.promisifyAll(libvirt.Interface.prototype);
-Promise.promisifyAll(libvirt.Network.prototype);
-Promise.promisifyAll(libvirt.NetworkFilter.prototype);
-Promise.promisifyAll(libvirt.Secret.prototype);
-Promise.promisifyAll(libvirt.StoragePool.prototype);
-Promise.promisifyAll(libvirt.StorageVolume.prototype);
+function LibvirtError(message) {
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = message;
+}
+
+require('util').inherits(LibvirtError, Error);
+
+function errorHandler(err) {
+  var newError = new LibvirtError(err.message);
+  for(var key in err) {
+    newError[key] = err[key];
+  }
+  throw newError;
+}
+
+var promisifyOptions = {
+  promisifier: function(originalFunction, defaultPromisifer) {
+    var promisified = defaultPromisifer(originalFunction);
+    return function() {
+      return promisified.apply(this, arguments)
+        .catch(errorHandler);
+    };
+  }
+};
+
+Promise.promisifyAll(libvirt.Hypervisor.prototype, promisifyOptions);
+Promise.promisifyAll(libvirt.Domain.prototype, promisifyOptions);
+Promise.promisifyAll(libvirt.NodeDevice.prototype, promisifyOptions);
+Promise.promisifyAll(libvirt.Interface.prototype, promisifyOptions);
+Promise.promisifyAll(libvirt.Network.prototype, promisifyOptions);
+Promise.promisifyAll(libvirt.NetworkFilter.prototype, promisifyOptions);
+Promise.promisifyAll(libvirt.Secret.prototype, promisifyOptions);
+Promise.promisifyAll(libvirt.StoragePool.prototype, promisifyOptions);
+Promise.promisifyAll(libvirt.StorageVolume.prototype, promisifyOptions);
 
 inherits(libvirt.Domain, EventEmitter);
 
@@ -46,12 +72,4 @@ libvirt.createHypervisor = function(uri, options) {
 };
 
 module.exports = libvirt;
-
-// module.exports = {
-//   libvirt: libvirt,
-//   Promise: Promise,
-//   startEventLoop: libvirt.setupEvent,
-//   createHypervisor: function(uri, options) {
-//     return new libvirt.Hypervisor(uri, options);
-//   }
-// };
+module.exports.LibvirtError = LibvirtError;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libvirt",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "author": {
     "name": "Camilo Aguilar",
     "email": "camilo@hooklift.io",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libvirt",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "author": {
     "name": "Camilo Aguilar",
     "email": "camilo@hooklift.io",

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -2118,7 +2118,7 @@ NAN_METHOD(Domain::SetSchedulerParameters)
 
   type = virDomainGetSchedulerType(domain->handle_, &nparams);
   if (type == NULL) {
-    Nan::ThrowError(Error::New(virSaveLastError()));
+    ThrowLastVirError();
     return info.GetReturnValue().Set(Nan::False());
   }
   free(type);
@@ -2133,7 +2133,7 @@ NAN_METHOD(Domain::SetSchedulerParameters)
 
   ret = virDomainGetSchedulerParameters(domain->handle_, params, &nparams);
   if(ret == -1) {
-    Nan::ThrowError(Error::New(virSaveLastError()));
+    ThrowLastVirError();
     free(params);
     return info.GetReturnValue().Set(Nan::False());
   }
@@ -2170,7 +2170,7 @@ NAN_METHOD(Domain::SetSchedulerParameters)
 
   ret = virDomainSetSchedulerParameters(domain->handle_, params, nparams);
   if (ret == -1) {
-    Nan::ThrowError(Error::New(virSaveLastError()));
+    ThrowLastVirError();
     free(params);
     return info.GetReturnValue().Set(Nan::False());
   }

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -122,10 +122,12 @@ void Domain::Initialize(Handle<Object> exports)
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SNAPSHOT_CREATE_NO_METADATA);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SNAPSHOT_CREATE_HALT);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SNAPSHOT_CREATE_DISK_ONLY);
+  #if LIBVIR_CHECK_VERSION(0,9,10)
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SNAPSHOT_CREATE_REUSE_EXT);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SNAPSHOT_CREATE_QUIESCE);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SNAPSHOT_CREATE_ATOMIC);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SNAPSHOT_CREATE_LIVE);
+  #endif
 
   //virDomainSnapshotDelete
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SNAPSHOT_DELETE_CHILDREN);
@@ -137,6 +139,7 @@ void Domain::Initialize(Handle<Object> exports)
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_AFFECT_LIVE);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_AFFECT_CONFIG);
 
+#ifdef _HAVE_DOMAIN_BLOCKCOMMIT_API
   //virDomainBlockCommit
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_BLOCK_COMMIT_SHALLOW);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_BLOCK_COMMIT_DELETE);
@@ -155,6 +158,7 @@ void Domain::Initialize(Handle<Object> exports)
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_BLOCK_JOB_TYPE_COPY);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_BLOCK_JOB_TYPE_COMMIT);
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_BLOCK_JOB_TYPE_ACTIVE_COMMIT);
+#endif
 
   //virDomainXMLFlags
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_XML_SECURE);
@@ -1524,6 +1528,9 @@ NLV_WORKER_EXECUTE(Domain, SetVcpus)
 #include <unistd.h>
 NAN_METHOD(Domain::BlockCommit)
 {
+  #ifndef _HAVE_DOMAIN_BLOCKCOMMIT_API
+  Nan::ThrowTypeError("blockcommit api not supported in this libvirt version");
+  #else
   Nan::HandleScope scope;
   if (info.Length() < 5 || !info[0]->IsString() || !info[1]->IsString() || !info[2]->IsString()
       || !info[3]->IsNumber()) {
@@ -1544,10 +1551,14 @@ NAN_METHOD(Domain::BlockCommit)
     }
     return onFinished(PrimitiveReturnHandler(true));
   });
+  #endif
 }
 
 NAN_METHOD(Domain::BlockJobInfo)
 {
+  #ifndef _HAVE_DOMAIN_BLOCKCOMMIT_API
+  Nan::ThrowTypeError("blockcommit api not supported in this libvirt version");
+  #else
   Nan::HandleScope scope;
   if (info.Length() < 1 || !info[0]->IsString()) {
     Nan::ThrowTypeError("you must specify path and optionally flags");
@@ -1579,10 +1590,14 @@ NAN_METHOD(Domain::BlockJobInfo)
       callback->Call(2, argv);
     });
   });
+  #endif
 }
 
 NAN_METHOD(Domain::BlockJobAbort)
 {
+  #ifndef _HAVE_DOMAIN_BLOCKCOMMIT_API
+  Nan::ThrowTypeError("blockcommit api not supported in this libvirt version");
+  #else
   if (info.Length() < 1 || !info[0]->IsString()) {
     Nan::ThrowTypeError("you must specify path and optionally flags");
     return;
@@ -1600,6 +1615,7 @@ NAN_METHOD(Domain::BlockJobAbort)
     }
     return onFinished(PrimitiveReturnHandler(true));
   });
+  #endif
 }
 
 NAN_METHOD(Domain::SendKeys)

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -185,6 +185,10 @@ void Domain::Initialize(Handle<Object> exports)
 
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_SEND_KEY_MAX_KEYS);
 
+  // virDomainUndefineFlags
+  NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_UNDEFINE_SNAPSHOTS_METADATA);
+  NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_UNDEFINE_MANAGED_SAVE);
+
   // ETC
   NODE_DEFINE_CONSTANT(exports, VIR_DOMAIN_EVENT_ID_LIFECYCLE);
 }
@@ -390,11 +394,11 @@ NLV_WORKER_EXECUTE(Domain, CoreDump)
   data_ = true;
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, Undefine)
+NLV_WORKER_METHOD_FLAGS(Domain, Undefine)
 NLV_WORKER_EXECUTE(Domain, Undefine)
 {
   NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainUndefine(Handle());
+  int result = virDomainUndefineFlags(Handle(), flags);
   if (result == -1) {
     SetVirError(virSaveLastError());
     return;

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -1568,7 +1568,7 @@ NAN_METHOD(Domain::BlockJobInfo)
       return onFinished(PrimitiveReturnHandler(false));
     }
     
-    return onFinished([&](Nan::Callback* callback) {
+    return onFinished([=](Nan::Callback* callback) {
       Nan::HandleScope scope;
       v8::Local<Object> data = Nan::New<Object>();
       data->Set(Nan::New("type").ToLocalChecked(), Nan::New<Integer>((unsigned int)info.type));

--- a/src/domain.h
+++ b/src/domain.h
@@ -10,6 +10,7 @@
 
 #if LIBVIR_CHECK_VERSION(0,9,10)
 #define _HAVE_DOMAIN_METADATA_API 1
+#define _HAVE_DOMAIN_BLOCKCOMMIT_API 1
 #endif
 
 namespace NLV {

--- a/src/domain.h
+++ b/src/domain.h
@@ -171,7 +171,7 @@ private:
   NLV_PRIMITIVE_RETURN_WORKER(AbortCurrentJob, virDomainPtr, bool);
   NLV_PRIMITIVE_RETURN_WORKER(ManagedSave, virDomainPtr, bool);
   NLV_PRIMITIVE_RETURN_WORKER(ManagedSaveRemove, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(Undefine, virDomainPtr, bool);
+  NLV_PRIMITIVE_RETURN_WORKER_WITH_FLAGS(Undefine, virDomainPtr, bool);
 
   class SaveWorker : public NLVPrimitiveReturnWorker<virDomainPtr, bool> {
   public:

--- a/src/domain.h
+++ b/src/domain.h
@@ -305,15 +305,6 @@ private:
     unsigned int flags_;
   };
 
-  class DeleteSnapshotWorker : public NLVAsyncWorker<virDomainPtr> {
-  public:
-    DeleteSnapshotWorker(Nan::Callback *callback, virDomainPtr handle, const std::string &name)
-      : NLVAsyncWorker<virDomainPtr>(callback, handle), name_(name) {}
-    void Execute();
-  private:
-    std::string name_;
-  };
-
   class LookupSnapshotByNameWorker : public NLVStringReturnWorker<virDomainPtr, std::string> {
   public:
     LookupSnapshotByNameWorker(Nan::Callback *callback, virDomainPtr handle, const std::string &name)

--- a/src/error.cc
+++ b/src/error.cc
@@ -20,6 +20,7 @@ void Error::Initialize(Handle<Object> exports)
   Nan::SetAccessor(ot, Nan::New("str3").ToLocalChecked(), Error::Getter);
   Nan::SetAccessor(ot, Nan::New("int1").ToLocalChecked(), Error::Getter);
   Nan::SetAccessor(ot, Nan::New("int2").ToLocalChecked(), Error::Getter);
+  Nan::SetAccessor(ot, Nan::New("context").ToLocalChecked(), Error::Getter);
 
   constructor.Reset(t->GetFunction());
 
@@ -147,10 +148,11 @@ void Error::Initialize(Handle<Object> exports)
   NODE_DEFINE_CONSTANT(exports, VIR_ERR_ERROR);
 }
 
-Error::Error(virErrorPtr error)
+Error::Error(virErrorPtr error, const char* context)
   : Nan::ObjectWrap()
 {
   error_ = error;
+  context_ = context;
 }
 
 Error::~Error()
@@ -158,13 +160,14 @@ Error::~Error()
   virFreeError(error_);
 }
 
-Local<Value> Error::New(virErrorPtr error)
+Local<Value> Error::New(virErrorPtr error, const char* context)
 {
   Nan::EscapableHandleScope scope;
 
   Local<Function> ctor = Nan::New<Function>(constructor);
+  
   Local<Object> instance = ctor->NewInstance();
-  Error *err = new Error(error);
+  Error *err = new Error(error, context);
   err->Wrap(instance);
   return scope.Escape(instance);
 }
@@ -194,6 +197,8 @@ NAN_GETTER(Error::Getter)
     return info.GetReturnValue().Set(Nan::New(error_->int1));
   } else if (property->Equals(Nan::New("int2").ToLocalChecked())) {
     return info.GetReturnValue().Set(Nan::New(error_->int2));
+  } else if (property->Equals(Nan::New("context").ToLocalChecked())) {
+    return info.GetReturnValue().Set(Nan::New(error->context_).ToLocalChecked());
   }
 
   return;

--- a/src/error.h
+++ b/src/error.h
@@ -10,19 +10,25 @@ class Error : public Nan::ObjectWrap
 {
 public:
   static void Initialize(Handle<Object> exports);
-  static Local<Value> New(virErrorPtr error);
+  static Local<Value> New(virErrorPtr error, const char* context);
 
 private:
-  explicit Error(virErrorPtr error);
+  explicit Error(virErrorPtr error, const char* context);
   ~Error();
   static Nan::Persistent<Function> constructor;
 
   static NAN_GETTER(Getter);
 
   virErrorPtr error_;
-
+  const char* context_;
 };
 
 } //namespace NLV
+
+#define _LIBVIRT_STRINGIZE_DETAIL(x) #x
+#define _LIBVIRT_STRINGIZE(x) _LIBVIRT_STRINGIZE_DETAIL(x)
+
+#define ThrowLastVirError() Nan::ThrowError(Error::New(virSaveLastError(), __FILE__ ":" _LIBVIRT_STRINGIZE(__LINE__)))
+#define MakeVirError() Error::New(VirError(), __FILE__ ":" _LIBVIRT_STRINGIZE(__LINE__))
 
 #endif // ERROR_H

--- a/src/nlv_async_worker.cc
+++ b/src/nlv_async_worker.cc
@@ -52,7 +52,7 @@ void NLVAsyncWorkerBase::HandleErrorCallback()
 {
   Nan::HandleScope scope;
   if (virError_ != NULL) {
-    v8::Local<v8::Value> argv[] = { Error::New(VirError()) };
+    v8::Local<v8::Value> argv[] = { MakeVirError() };
     // the reference to virError will be cleaned up by Error object now
     virError_ = NULL;
     callback->Call(1, argv);

--- a/src/nlv_async_worker.h
+++ b/src/nlv_async_worker.h
@@ -50,6 +50,18 @@ private:
 };
 
 /**
+ * Worker that returns a primitive to javascript and takes flags
+ */
+#define NLV_PRIMITIVE_RETURN_WORKER_WITH_FLAGS(Method, HandleType, PrimitiveType)  \
+  class Method##Worker : public NLVPrimitiveReturnWorker<HandleType, PrimitiveType> { \
+    unsigned int flags; \
+  public: \
+    Method##Worker(Nan::Callback *callback, HandleType handle, unsigned int _flags = 0) \
+      : NLVPrimitiveReturnWorker<HandleType, PrimitiveType>(callback, handle), flags(_flags) {} \
+    void Execute(); \
+  };
+
+/**
  * Worker that returns a primitive to javascript
  */
 #define NLV_PRIMITIVE_RETURN_WORKER(Method, HandleType, PrimitiveType)  \

--- a/src/nlv_async_worker.h
+++ b/src/nlv_async_worker.h
@@ -32,6 +32,7 @@ private:
 
 };
 
+
 /**
  * Base class for most NLV async workers
  */

--- a/src/nlv_object.h
+++ b/src/nlv_object.h
@@ -102,7 +102,7 @@ NAN_INLINE void AsyncQueueWorker(Nan::AsyncWorker *worker, Local<Object> parent 
   Nan::AsyncQueueWorker(worker);
 }
 
-NAN_INLINE unsigned int GetFlags(v8::Handle<v8::Value> val) {
+NAN_INLINE unsigned int GetFlags(v8::Local<v8::Value> val) {
   if(val->IsUndefined() || val->IsFunction()) {
     return 0;
   }

--- a/src/nlv_object.h
+++ b/src/nlv_object.h
@@ -102,6 +102,22 @@ NAN_INLINE void AsyncQueueWorker(Nan::AsyncWorker *worker, Local<Object> parent 
   Nan::AsyncQueueWorker(worker);
 }
 
+NAN_INLINE unsigned int GetFlags(v8::Handle<v8::Value> val) {
+  if(val->IsUndefined() || val->IsFunction()) {
+    return 0;
+  }
+  if(!val->IsArray()) {
+    Nan::ThrowTypeError("flags must be an array");
+    return 0;
+  }
+  
+  Local<Array> flags_ = Local<Array>::Cast(val);
+  unsigned int flags = 0;
+  for (unsigned int i = 0; i < flags_->Length(); i++)
+    flags |= flags_->Get(Nan::New<Integer>(i))->Int32Value();
+  return flags;
+}
+
 };
 
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1,0 +1,13 @@
+#include "worker.h"
+
+using namespace NLV;
+
+void Worker::Queue(v8::Handle<v8::Value> v8_callback, ExecuteHandler handler) {
+  if(!v8_callback->IsFunction()) {
+    Nan::ThrowTypeError("you must specify a function as the callback");;
+    return;
+  }
+  Nan::Callback *callback = new Nan::Callback(v8_callback.As<Function>());
+  auto worker = new NLV::Worker(callback, handler);
+  Nan::AsyncQueueWorker(worker);
+}

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -2,7 +2,7 @@
 
 using namespace NLV;
 
-void Worker::Queue(v8::Handle<v8::Value> v8_callback, ExecuteHandler handler) {
+void Worker::Queue(v8::Local<v8::Value> v8_callback, ExecuteHandler handler) {
   if(!v8_callback->IsFunction()) {
     Nan::ThrowTypeError("you must specify a function as the callback");;
     return;

--- a/src/worker.h
+++ b/src/worker.h
@@ -31,7 +31,7 @@ namespace NLV {
     
     // TODO: make it a template so that it can accept arbitrary number of arguments
     // of objects to make persistent for the duration of the worker run
-    static void Queue(v8::Handle<v8::Value> v8_callback, ExecuteHandler handler);
+    static void Queue(v8::Local<v8::Value> v8_callback, ExecuteHandler handler);
   };
   
   template<class T>

--- a/src/worker.h
+++ b/src/worker.h
@@ -1,0 +1,45 @@
+#include "nlv_async_worker.h"
+
+namespace NLV {
+  class Worker : public NLVAsyncWorkerBase {
+  public:
+    typedef std::function<void(Nan::Callback*)>  OnFinishedHandler;
+    
+    typedef std::function<virErrorPtr(OnFinishedHandler)> SetOnFinishedHandler;
+    
+    typedef std::function<virErrorPtr(SetOnFinishedHandler)> ExecuteHandler;
+    
+    ExecuteHandler execute_handler;
+    OnFinishedHandler on_finished_handler;
+    
+    explicit Worker(Nan::Callback *callback, ExecuteHandler handler)
+      : NLVAsyncWorkerBase(callback), execute_handler(handler) { };
+    
+    void HandleOKCallback() {
+      on_finished_handler(callback);
+    }
+    
+    virtual void Execute() {
+      auto error = execute_handler([=] (OnFinishedHandler handler) {
+        on_finished_handler = handler;
+        return nullptr;
+      });
+      if(error) {
+        SetVirError(error);
+      }
+    }
+    
+    // TODO: make it a template so that it can accept arbitrary number of arguments
+    // of objects to make persistent for the duration of the worker run
+    static void Queue(v8::Handle<v8::Value> v8_callback, ExecuteHandler handler);
+  };
+  
+  template<class T>
+  Worker::OnFinishedHandler PrimitiveReturnHandler(T val) {
+    return [=](Nan::Callback* callback) {
+      Nan::HandleScope scope;
+      v8::Local<v8::Value> argv[] = { Nan::Null(), Nan::New(val) };
+      callback->Call(2, argv);
+    };
+  }
+};

--- a/src/worker_macros.h
+++ b/src/worker_macros.h
@@ -52,6 +52,27 @@
     return; \
   }
 
+// METHOD HELPERS
+#define NLV_WORKER_METHOD_FLAGS(Class, Method) \
+  NAN_METHOD(Class::Method) {  \
+    Nan::HandleScope scope; \
+    unsigned int flags = 0; \
+    Nan::Callback *callback; \
+    if (info.Length() > 1 && info[1]->IsFunction()) \
+    { \
+      callback = new Nan::Callback(info[1].As<Function>()); \
+      flags = info[0]->IntegerValue(); \
+    } else if (info.Length() == 1 && info[0]->IsFunction()) { \
+      callback = new Nan::Callback(info[0].As<Function>()); \
+    } else { \
+      Nan::ThrowTypeError("signature is callback or flags, callback"); \
+      return; \
+    } \
+    Class *object = Nan::ObjectWrap::Unwrap<Class>(info.This()); \
+    Nan::AsyncQueueWorker(new Method##Worker(callback, object->handle_, flags));  \
+    return; \
+  }
+
 #define NLV_WORKER_METHOD_DEFINE(Class) \
   NAN_METHOD(Class::Define) { \
     Nan::HandleScope scope; \


### PR DESCRIPTION
Also add some context information to native errors.

What do y'all think? For me Libvirt errors not extending Error was a big problem cause there was no stacktrace.

Additional plus, you can now catch errors from node-libvirt via `.catch(libvirt.LibvirtError, err =>`