### PR TITLE
Feature/simplify methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "bindings": "^1.2.1",
     "bluebird": "^3.1.1",
-    "nan": "^2.1.0"
+    "nan": "^2.4.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -534,7 +534,11 @@ NAN_METHOD(Domain::Reset)
 
 NAN_METHOD(Domain::Shutdown)
 {
+#if LIBVIR_CHECK_VERSION(0,9,10)
   MethodWithFlags(info, virDomainShutdownFlags);
+#else
+  MethodNoArgs(info, virDomainShutdown);
+#endif
 }
 
 NAN_METHOD(Domain::Suspend)

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -427,98 +427,39 @@ NLV_WORKER_EXECUTE(Domain, CoreDump)
   data_ = true;
 }
 
-NLV_WORKER_METHOD_FLAGS(Domain, Undefine)
-NLV_WORKER_EXECUTE(Domain, Undefine)
+NAN_METHOD(Domain::Undefine)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainUndefineFlags(Handle(), flags);
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodWithFlags(info, virDomainUndefineFlags);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, Destroy)
-NLV_WORKER_EXECUTE(Domain, Destroy)
+NAN_METHOD(Domain::Destroy)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainDestroy(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodNoArgs(info, virDomainDestroy);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, ManagedSave)
-NLV_WORKER_EXECUTE(Domain, ManagedSave)
+NAN_METHOD(Domain::ManagedSave)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  unsigned int flags = 0;
-  int result = virDomainManagedSave(Handle(), flags);
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodWithFlags(info, virDomainManagedSave);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, ManagedSaveRemove)
-NLV_WORKER_EXECUTE(Domain, ManagedSaveRemove)
+NAN_METHOD(Domain::ManagedSaveRemove)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  unsigned int flags = 0;
-  int result = virDomainManagedSaveRemove(Handle(), flags);
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodWithFlags(info, virDomainManagedSaveRemove);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, GetName)
-NLV_WORKER_EXECUTE(Domain, GetName)
+NAN_METHOD(Domain::GetName)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  const char *result = virDomainGetName(Handle());
-  if (result == NULL) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = result;
+  MethodNoArgs<MethodReturnString>(info, virDomainGetName);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, GetId)
-NLV_WORKER_EXECUTE(Domain, GetId)
+NAN_METHOD(Domain::GetId)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  unsigned int result = virDomainGetID(Handle());
-  if (result == -1u) {
-    data_ = -1;
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = result;
+  MethodNoArgs<MethodReturnInt>(info, virDomainGetID);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, GetOSType)
-NLV_WORKER_EXECUTE(Domain, GetOSType)
+NAN_METHOD(Domain::GetOSType)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  const char *result = virDomainGetOSType(Handle());
-  if (result == NULL) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = result;
+  MethodNoArgs<MethodReturnString>(info, virDomainGetOSType);
 }
 
 NLV_WORKER_METHOD_NO_ARGS(Domain, GetUUID)
@@ -551,165 +492,66 @@ NLV_WORKER_EXECUTE(Domain, GetAutostart)
   data_ = static_cast<bool>(autostart);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, GetMaxMemory)
-NLV_WORKER_EXECUTE(Domain, GetMaxMemory)
+NAN_METHOD(Domain::GetMaxMemory)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  unsigned long result = virDomainGetMaxMemory(Handle());
-  if (result == 0) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = result;
+  MethodNoArgs<MethodReturn<double>>(info, virDomainGetMaxMemory);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, GetMaxVcpus)
-NLV_WORKER_EXECUTE(Domain, GetMaxVcpus)
+NAN_METHOD(Domain::GetMaxVcpus)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainGetMaxVcpus(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = result;
+  MethodNoArgs<MethodReturnInt>(info, virDomainGetMaxVcpus);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, IsActive)
-NLV_WORKER_EXECUTE(Domain, IsActive)
+NAN_METHOD(Domain::IsActive)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainIsActive(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = static_cast<bool>(result);
+  MethodNoArgs<MethodReturnBool>(info, virDomainIsActive);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, IsPersistent)
-NLV_WORKER_EXECUTE(Domain, IsPersistent)
+NAN_METHOD(Domain::IsPersistent)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainIsPersistent(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = static_cast<bool>(result);
+  MethodNoArgs<MethodReturnBool>(info, virDomainIsPersistent);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, IsUpdated)
-NLV_WORKER_EXECUTE(Domain, IsUpdated)
+NAN_METHOD(Domain::IsUpdated)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainIsUpdated(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = static_cast<bool>(result);
+  MethodNoArgs<MethodReturnBool>(info, virDomainIsUpdated);
 }
 
-
-NLV_WORKER_METHOD_NO_ARGS(Domain, Start)
-NLV_WORKER_EXECUTE(Domain, Start)
+NAN_METHOD(Domain::Start)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainCreate(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodNoArgs(info, virDomainCreate);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, Reboot)
-NLV_WORKER_EXECUTE(Domain, Reboot)
+NAN_METHOD(Domain::Reboot)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  unsigned long flags = 0;
-  int result = virDomainReboot(Handle(), flags);
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodWithFlags(info, virDomainReboot);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, Reset)
-NLV_WORKER_EXECUTE(Domain, Reset)
+NAN_METHOD(Domain::Reset)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  unsigned long flags = 0;
-  int result = virDomainReset(Handle(), flags);
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodWithFlags(info, virDomainReset);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, Shutdown)
-NLV_WORKER_EXECUTE(Domain, Shutdown)
+NAN_METHOD(Domain::Shutdown)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainShutdown(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodWithFlags(info, virDomainShutdownFlags);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, Suspend)
-NLV_WORKER_EXECUTE(Domain, Suspend)
+NAN_METHOD(Domain::Suspend)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainSuspend(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodNoArgs(info, virDomainSuspend);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, Resume)
-NLV_WORKER_EXECUTE(Domain, Resume)
+NAN_METHOD(Domain::Resume)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  int result = virDomainResume(Handle());
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = true;
+  MethodNoArgs(info, virDomainResume);
 }
 
-NLV_WORKER_METHOD_NO_ARGS(Domain, HasManagedSaveImage)
-NLV_WORKER_EXECUTE(Domain, HasManagedSaveImage)
+NAN_METHOD(Domain::HasManagedSaveImage)
 {
-  NLV_WORKER_ASSERT_DOMAIN();
-  unsigned long flags = 0;
-  int result = virDomainHasManagedSaveImage(Handle(), flags);
-  if (result == -1) {
-    SetVirError(virSaveLastError());
-    return;
-  }
-
-  data_ = static_cast<bool>(result);
+  MethodWithFlags<MethodReturnBool>(info, virDomainHasManagedSaveImage);
 }
+
 
 NAN_METHOD(Domain::SetAutostart)
 {

--- a/src/domain.cc
+++ b/src/domain.cc
@@ -429,37 +429,37 @@ NLV_WORKER_EXECUTE(Domain, CoreDump)
 
 NAN_METHOD(Domain::Undefine)
 {
-  MethodWithFlags(info, virDomainUndefineFlags);
+  RunMethod(info, virDomainUndefineFlags, GetFlags(info[0]));
 }
 
 NAN_METHOD(Domain::Destroy)
 {
-  MethodNoArgs(info, virDomainDestroy);
+  RunMethod(info, virDomainDestroy);
 }
 
 NAN_METHOD(Domain::ManagedSave)
 {
-  MethodWithFlags(info, virDomainManagedSave);
+  RunMethod(info, virDomainManagedSave, GetFlags(info[0]));
 }
 
 NAN_METHOD(Domain::ManagedSaveRemove)
 {
-  MethodWithFlags(info, virDomainManagedSaveRemove);
+  RunMethod(info, virDomainManagedSaveRemove, GetFlags(info[0]));
 }
 
 NAN_METHOD(Domain::GetName)
 {
-  MethodNoArgs<MethodReturnString>(info, virDomainGetName);
+  RunMethod<MethodReturnString>(info, virDomainGetName);
 }
 
 NAN_METHOD(Domain::GetId)
 {
-  MethodNoArgs<MethodReturnInt>(info, virDomainGetID);
+  RunMethod<MethodReturnInt>(info, virDomainGetID);
 }
 
 NAN_METHOD(Domain::GetOSType)
 {
-  MethodNoArgs<MethodReturnString>(info, virDomainGetOSType);
+  RunMethod<MethodReturnString>(info, virDomainGetOSType);
 }
 
 NLV_WORKER_METHOD_NO_ARGS(Domain, GetUUID)
@@ -494,66 +494,66 @@ NLV_WORKER_EXECUTE(Domain, GetAutostart)
 
 NAN_METHOD(Domain::GetMaxMemory)
 {
-  MethodNoArgs<MethodReturn<double>>(info, virDomainGetMaxMemory);
+  RunMethod<MethodReturn<double>>(info, virDomainGetMaxMemory);
 }
 
 NAN_METHOD(Domain::GetMaxVcpus)
 {
-  MethodNoArgs<MethodReturnInt>(info, virDomainGetMaxVcpus);
+  RunMethod<MethodReturnInt>(info, virDomainGetMaxVcpus);
 }
 
 NAN_METHOD(Domain::IsActive)
 {
-  MethodNoArgs<MethodReturnBool>(info, virDomainIsActive);
+  RunMethod<MethodReturnBool>(info, virDomainIsActive);
 }
 
 NAN_METHOD(Domain::IsPersistent)
 {
-  MethodNoArgs<MethodReturnBool>(info, virDomainIsPersistent);
+  RunMethod<MethodReturnBool>(info, virDomainIsPersistent);
 }
 
 NAN_METHOD(Domain::IsUpdated)
 {
-  MethodNoArgs<MethodReturnBool>(info, virDomainIsUpdated);
+  RunMethod<MethodReturnBool>(info, virDomainIsUpdated);
 }
 
 NAN_METHOD(Domain::Start)
 {
-  MethodNoArgs(info, virDomainCreate);
+  RunMethod(info, virDomainCreate);
 }
 
 NAN_METHOD(Domain::Reboot)
 {
-  MethodWithFlags(info, virDomainReboot);
+  RunMethod(info, virDomainReboot, GetFlags(info[0]));
 }
 
 NAN_METHOD(Domain::Reset)
 {
-  MethodWithFlags(info, virDomainReset);
+  RunMethod(info, virDomainReset, GetFlags(info[0]));
 }
 
 NAN_METHOD(Domain::Shutdown)
 {
 #if LIBVIR_CHECK_VERSION(0,9,10)
-  MethodWithFlags(info, virDomainShutdownFlags);
+  RunMethod(info, virDomainShutdownFlags, GetFlags(info[0]));
 #else
-  MethodNoArgs(info, virDomainShutdown);
+  RunMethod(info, virDomainShutdown);
 #endif
 }
 
 NAN_METHOD(Domain::Suspend)
 {
-  MethodNoArgs(info, virDomainSuspend);
+  RunMethod(info, virDomainSuspend);
 }
 
 NAN_METHOD(Domain::Resume)
 {
-  MethodNoArgs(info, virDomainResume);
+  RunMethod(info, virDomainResume);
 }
 
 NAN_METHOD(Domain::HasManagedSaveImage)
 {
-  MethodWithFlags<MethodReturnBool>(info, virDomainHasManagedSaveImage);
+  RunMethod<MethodReturnBool>(info, virDomainHasManagedSaveImage, GetFlags(info[0]));
 }
 
 

--- a/src/domain.h
+++ b/src/domain.h
@@ -116,22 +116,7 @@ private:
   // UNFINISHED SYNC ACCESSORS/MUTATORS
   static NAN_METHOD(SetSchedulerParameters);
 
-private:
-  // HYPERVISOR METHOD WORKERS
-  NLV_LOOKUP_BY_VALUE_WORKER(LookupByName, Domain, Hypervisor, virDomainPtr);
-  NLV_LOOKUP_BY_VALUE_WORKER(LookupByUUID, Domain, Hypervisor, virDomainPtr);
-  NLV_LOOKUP_BY_VALUE_WORKER(Create, Domain, Hypervisor, virDomainPtr);
-  NLV_LOOKUP_BY_VALUE_WORKER(Define, Domain, Hypervisor, virDomainPtr);
-
-  class LookupByIdWorker : public NLVLookupInstanceByValueWorker<Domain, Hypervisor, virDomainPtr> {
-  public:
-    LookupByIdWorker(Nan::Callback *callback, Hypervisor *parent, int id)
-      : NLVLookupInstanceByValueWorker<Domain, Hypervisor, virDomainPtr>(callback, parent, std::string()), id_(id) {}
-    void Execute();
-  private:
-    int id_;
-  };
-
+private:  
   class RestoreWorker : public NLVPrimitiveReturnWorker<virConnectPtr, bool> {
   public:
     RestoreWorker(Nan::Callback *callback, virConnectPtr handle, const std::string &path)
@@ -312,8 +297,6 @@ private:
 
   // ACCESSOR/MUTATOR METHOD WORKERS
   NLV_OBJECT_RETURN_WORKER(GetInfo, virDomainPtr, virDomainInfo);
-  NLV_STRING_RETURN_WORKER(GetUUID, virDomainPtr, std::string);
-  NLV_PRIMITIVE_RETURN_WORKER(GetAutostart, virDomainPtr, bool);
   NLV_PRIMITIVE_RETURN_WORKER(HasManagedSaveImage, virDomainPtr, bool);
   NLV_STRING_RETURN_WORKER(GetSchedulerType, virDomainPtr, std::string);
   NLV_TYPED_PARAMETER_RETURN_WORKER(GetSchedulerParameters, virDomainPtr, virSchedParameter);

--- a/src/domain.h
+++ b/src/domain.h
@@ -170,17 +170,7 @@ private:
   };
 
   // ACTION METHOD WORKERS
-  NLV_PRIMITIVE_RETURN_WORKER(Destroy, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(Start, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(Reboot, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(Reset, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(Suspend, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(Resume, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(Shutdown, virDomainPtr, bool);
   NLV_PRIMITIVE_RETURN_WORKER(AbortCurrentJob, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(ManagedSave, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(ManagedSaveRemove, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER_WITH_FLAGS(Undefine, virDomainPtr, bool);
 
   class SaveWorker : public NLVPrimitiveReturnWorker<virDomainPtr, bool> {
   public:
@@ -321,17 +311,9 @@ private:
   };
 
   // ACCESSOR/MUTATOR METHOD WORKERS
-  NLV_STRING_RETURN_WORKER(GetName, virDomainPtr, std::string);
   NLV_OBJECT_RETURN_WORKER(GetInfo, virDomainPtr, virDomainInfo);
-  NLV_PRIMITIVE_RETURN_WORKER(GetId, virDomainPtr, int);
-  NLV_STRING_RETURN_WORKER(GetOSType, virDomainPtr, std::string);
   NLV_STRING_RETURN_WORKER(GetUUID, virDomainPtr, std::string);
   NLV_PRIMITIVE_RETURN_WORKER(GetAutostart, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(GetMaxMemory, virDomainPtr, double);
-  NLV_PRIMITIVE_RETURN_WORKER(GetMaxVcpus, virDomainPtr, int);
-  NLV_PRIMITIVE_RETURN_WORKER(IsActive, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(IsPersistent, virDomainPtr, bool);
-  NLV_PRIMITIVE_RETURN_WORKER(IsUpdated, virDomainPtr, bool);
   NLV_PRIMITIVE_RETURN_WORKER(HasManagedSaveImage, virDomainPtr, bool);
   NLV_STRING_RETURN_WORKER(GetSchedulerType, virDomainPtr, std::string);
   NLV_TYPED_PARAMETER_RETURN_WORKER(GetSchedulerParameters, virDomainPtr, virSchedParameter);

--- a/src/nlv_async_worker.h
+++ b/src/nlv_async_worker.h
@@ -11,29 +11,6 @@
 #include "nlv_object.h"
 
 /**
- * Base class for all workers in node-libvirt
- */
-class NLVAsyncWorkerBase : public Nan::AsyncWorker
-{
-public:
-  explicit NLVAsyncWorkerBase(Nan::Callback *callback);
-  ~NLVAsyncWorkerBase();
-
-  virErrorPtr VirError() const;
-  void SetVirError(virErrorPtr error);
-
-  virtual void WorkComplete();
-
-protected:
-  virtual void HandleErrorCallback();
-
-private:
-  virErrorPtr virError_;
-
-};
-
-
-/**
  * Base class for most NLV async workers
  */
 template <typename T>

--- a/src/nlv_base.h
+++ b/src/nlv_base.h
@@ -1,0 +1,80 @@
+#ifndef NLV_BASE_H
+#define NLV_BASE_H
+
+#include <nan.h>
+#include <libvirt/libvirt.h>
+#include <libvirt/virterror.h>
+
+class NLVObjectBase;
+
+// hold a reference to a "child" object in a way that can be safely invalidated
+// if the child is destroyed by the GC before the parent.
+class NLVObjectBasePtr
+{
+public:
+  NLVObjectBasePtr(NLVObjectBase *ref) : ref_(ref), valid_(true) {}
+  bool IsValid() const { return valid_; }
+  NLVObjectBase* GetPointer() const {
+    if (!valid_) {
+      //Nan::ThrowReferenceError("attempt to access invalid NLVObjectBase pointer");
+      return NULL;
+    }
+
+    return ref_;
+  }
+
+  void SetInvalid() {
+    ref_ = NULL;
+    valid_ = false;
+  }
+
+protected:
+  NLVObjectBase *ref_;
+  bool valid_;
+};
+
+#define NLV_STRINGIFY0(v) #v
+#define NLV_STRINGIFY(v) NLV_STRINGIFY0(v)
+
+// macro could be removed but alternate solution seems overly complex
+// https://blog.molecular-matters.com/2015/12/11/getting-the-type-of-a-template-argument-as-string-without-rtti/
+#define NLV_OBJECT_STATIC_HELPERS(class_name) \
+  static const char* ClassName() { \
+    return NLV_STRINGIFY(class_name); \
+  } \
+  friend class NLVObject;
+
+
+class NLVObjectBase : public Nan::ObjectWrap
+{
+public:
+  virtual void ClearHandle() = 0;
+  virtual void ClearChildren() = 0;
+  virtual void SetParentReference(NLVObjectBasePtr *parentReference) = 0;
+
+  std::vector<NLVObjectBasePtr*> children_;
+};
+
+/**
+ * Base class for all workers in node-libvirt
+ */
+class NLVAsyncWorkerBase : public Nan::AsyncWorker
+{
+public:
+  explicit NLVAsyncWorkerBase(Nan::Callback *callback);
+  ~NLVAsyncWorkerBase();
+
+  virErrorPtr VirError() const;
+  void SetVirError(virErrorPtr error);
+
+  virtual void WorkComplete();
+
+protected:
+  virtual void HandleErrorCallback();
+
+private:
+  virErrorPtr virError_;
+
+};
+
+#endif // NLV_BASE_H

--- a/src/nlv_object.h
+++ b/src/nlv_object.h
@@ -74,7 +74,13 @@ namespace NLV {
       }
     };
     
+    static inline bool virHasFailed(int val) {
+      return val < 0;
+    }
     
+    static inline bool virHasFailed(const void* ptr) {
+      return ptr == nullptr;
+    }
 
     template<typename ReturnHandler = MethodNoReturnHandler, typename Z>
     static void MethodNoArgs(const Nan::FunctionCallbackInfo<v8::Value>& info, Z virFunction) {
@@ -82,7 +88,7 @@ namespace NLV {
       virDomainPtr domain = ParentClass::Unwrap(info.This())->virHandle();
       NLV::Worker::RunAsync(info, [=] (NLV::Worker::SetOnFinishedHandler onFinished) {
         auto retVal = virFunction(domain);
-        if (retVal < 0) {
+        if (virHasFailed(retVal)) {
           return virSaveLastError();
         }
         ReturnHandler returnHandler;

--- a/src/nlv_object.h
+++ b/src/nlv_object.h
@@ -5,182 +5,192 @@
 #include <assert.h>
 
 #include <memory>
-#include <nan.h>
+#include "nlv_base.h"
+
+#include "worker.h"
 using namespace node;
 using namespace v8;
 
-class NLVObjectBase;
-
-// hold a reference to a "child" object in a way that can be safely invalidated
-// if the child is destroyed by the GC before the parent.
-class NLVObjectBasePtr
-{
-public:
-  NLVObjectBasePtr(NLVObjectBase *ref) : ref_(ref), valid_(true) {}
-  bool IsValid() const { return valid_; }
-  NLVObjectBase* GetPointer() const {
-    if (!valid_) {
-      //Nan::ThrowReferenceError("attempt to access invalid NLVObjectBase pointer");
-      return NULL;
+namespace NLV {
+  NAN_INLINE unsigned int GetFlags(v8::Local<v8::Value> val) {
+    if(val->IsUndefined() || val->IsFunction()) {
+      return 0;
     }
-
-    return ref_;
-  }
-
-  void SetInvalid() {
-    ref_ = NULL;
-    valid_ = false;
-  }
-
-protected:
-  NLVObjectBase *ref_;
-  bool valid_;
-};
-
-#define NLV_STRINGIFY0(v) #v
-#define NLV_STRINGIFY(v) NLV_STRINGIFY0(v)
-
-// macro could be removed but alternate solution seems overly complex
-// https://blog.molecular-matters.com/2015/12/11/getting-the-type-of-a-template-argument-as-string-without-rtti/
-#define NLV_OBJECT_STATIC_HELPERS(class_name) \
-  static const char* ClassName() { \
-    return NLV_STRINGIFY(class_name); \
-  } \
-  friend class NLVObject;
-
-
-class NLVObjectBase : public Nan::ObjectWrap
-{
-public:
-  virtual void ClearHandle() = 0;
-  virtual void ClearChildren() = 0;
-  virtual void SetParentReference(NLVObjectBasePtr *parentReference) = 0;
-
-  std::vector<NLVObjectBasePtr*> children_;
-};
-
-template <typename ParentClass, typename HandleType, typename CleanupHandler>
-class NLVObject : public NLVObjectBase
-{
-public:
-  typedef HandleType handle_type;
-
-  typedef typename std::remove_pointer<HandleType>::type HandleValue;
-
-  NLVObject(HandleType handle) : handle_(handle, CleanupHandler::cleanup), parentReference_(NULL) {}
-  ~NLVObject() {
-    // calling virtual ClearHandle() will break if overridden by subclasses
-    ClearHandle();
-    if (parentReference_ != NULL) {
-      parentReference_->SetInvalid();
+    if(val->IsArray()) {
+      Local<Array> flags_ = Local<Array>::Cast(val);
+      unsigned int flags = 0;
+      for (unsigned int i = 0; i < flags_->Length(); i++)
+        flags |= flags_->Get(Nan::New<Integer>(i))->Int32Value();
+      return flags;
+    } else if(val->IsNumber()) {
+      return val->IntegerValue();
+    } else {
+      Nan::ThrowTypeError("flags must be an array or a number");
+      return 0;
     }
   }
 
-  static v8::Local<v8::Object> NewInstance(handle_type handle) {
-    Nan::EscapableHandleScope scope;
-    Local<Function> ctor = Nan::New<Function>(ParentClass::constructor);
-    Local<Object> object = Nan::NewInstance(ctor).ToLocalChecked();
-    ParentClass *class_instance = new ParentClass(handle);
-    class_instance->Wrap(object);
-    return scope.Escape(object);
-  }
+  template <typename ParentClass, typename HandleType, typename CleanupHandler>
+  class NLVObject : public NLVObjectBase
+  {
+  public:
+    typedef HandleType handle_type;
 
-  static bool IsInstanceOf(v8::Local<v8::Object> val) {
-    Nan::HandleScope scope;
-    return Nan::New(ParentClass::constructor_template)->HasInstance(val);
-  }
+    typedef typename std::remove_pointer<HandleType>::type HandleValue;
 
-  const HandleType virHandle() const {
-    return handle_.get();
-   }
-
-
-  NAN_INLINE static ParentClass* Unwrap(v8::Local<v8::Object> val) {
-    if(!ParentClass::IsInstanceOf(val)) {
-      char error[128];
-      snprintf(error, sizeof(error), "Expecting object to be %s", ParentClass::ClassName());
-      Nan::ThrowTypeError(error);
-      return nullptr;
-    }
-
-    return ObjectWrap::Unwrap<ParentClass>(val);
-  }
-
-  NAN_INLINE static ParentClass* Unwrap(v8::Local<v8::Value> val) {
-    if(!val->IsObject()) {
-      char error[128];
-      snprintf(error, sizeof(error), "Cannot unwrap handle from non-object, expecting %s", ParentClass::ClassName());
-      Nan::ThrowTypeError(error);
-      return nullptr;
-    }
-
-    return Unwrap(val->ToObject());
-  }
-
-  NAN_INLINE static HandleType UnwrapHandle(v8::Local<v8::Value> val) {
-    return Unwrap(val)->virHandle();
-  }
-
-  template<class T>
-  NAN_INLINE static HandleType UnwrapHandle(v8::Local<v8::Object> val) {
-    return Unwrap(val)->virHandle();
-  }
-
-  virtual void ClearHandle() {
-    handle_.reset();
-  }
-
-  virtual void ClearChildren() {
-    std::vector<NLVObjectBasePtr*>::const_iterator it;
-    for (it = children_.begin(); it != children_.end(); ++it) {
-      NLVObjectBasePtr *ptr = *it;
-      if (ptr->IsValid()) {
-        NLVObjectBase *obj = ptr->GetPointer();
-        obj->ClearChildren();
-        obj->ClearHandle();
-        obj->SetParentReference(NULL);
-        delete ptr;
+    NLVObject(HandleType handle) : handle_(handle, CleanupHandler::cleanup), parentReference_(NULL) {}
+    ~NLVObject() {
+      // calling virtual ClearHandle() will break if overridden by subclasses
+      ClearHandle();
+      if (parentReference_ != NULL) {
+        parentReference_->SetInvalid();
       }
     }
 
-    children_.clear();
+    struct MethodNoReturnHandler {
+      template<typename T>
+      Worker::OnFinishedHandler operator()(T val) {
+        return NLV::PrimitiveReturnHandler(true);
+      }
+    };
+
+    template<typename T>
+    struct MethodReturn {
+      Worker::OnFinishedHandler operator()(T val) {
+        return NLV::PrimitiveReturnHandler(static_cast<T>(val));
+      }
+    };
+    using MethodReturnBool = MethodReturn<bool>;
+    using MethodReturnInt = MethodReturn<int>;
+
+    struct MethodReturnString {
+      Worker::OnFinishedHandler operator()(const char* val) {
+        std::string str = val;
+        return [=](Worker* worker) {
+          Nan::HandleScope scope;
+          v8::Local<v8::Value> argv[] = { Nan::Null(), Nan::New(str).ToLocalChecked() };
+          worker->Call(2, argv);
+        };
+      }
+    };
+    
+    
+
+    template<typename ReturnHandler = MethodNoReturnHandler, typename Z>
+    static void MethodNoArgs(const Nan::FunctionCallbackInfo<v8::Value>& info, Z virFunction) {
+      Nan::HandleScope scope;
+      virDomainPtr domain = ParentClass::Unwrap(info.This())->virHandle();
+      NLV::Worker::RunAsync(info, [=] (NLV::Worker::SetOnFinishedHandler onFinished) {
+        auto retVal = virFunction(domain);
+        if (retVal < 0) {
+          return virSaveLastError();
+        }
+        ReturnHandler returnHandler;
+        return onFinished(returnHandler(retVal));
+      });
+    }
+    
+    template<typename ReturnHandler = MethodNoReturnHandler, typename Z>
+    static void MethodWithFlags(const Nan::FunctionCallbackInfo<v8::Value>& info, Z virFunction) {
+      Nan::HandleScope scope;
+      virDomainPtr domain = ParentClass::Unwrap(info.This())->virHandle();
+      unsigned int flags = GetFlags(info[0]);
+      NLV::Worker::RunAsync(info, [=] (NLV::Worker::SetOnFinishedHandler onFinished) {
+        auto retVal = virFunction(domain, flags);
+        if (retVal < 0) {
+          return virSaveLastError();
+        }
+        ReturnHandler returnHandler;
+        return onFinished(returnHandler(retVal));
+      });
+    }
+
+    static v8::Local<v8::Object> NewInstance(handle_type handle) {
+      Nan::EscapableHandleScope scope;
+      Local<Function> ctor = Nan::New<Function>(ParentClass::constructor);
+      Local<Object> object = Nan::NewInstance(ctor).ToLocalChecked();
+      ParentClass *class_instance = new ParentClass(handle);
+      class_instance->Wrap(object);
+      return scope.Escape(object);
+    }
+
+    static bool IsInstanceOf(v8::Local<v8::Object> val) {
+      Nan::HandleScope scope;
+      return Nan::New(ParentClass::constructor_template)->HasInstance(val);
+    }
+
+    const HandleType virHandle() const {
+      return handle_.get();
+     }
+
+
+    NAN_INLINE static ParentClass* Unwrap(v8::Local<v8::Object> val) {
+      if(!ParentClass::IsInstanceOf(val)) {
+        char error[128];
+        snprintf(error, sizeof(error), "Expecting object to be %s", ParentClass::ClassName());
+        Nan::ThrowTypeError(error);
+        return nullptr;
+      }
+
+      return ObjectWrap::Unwrap<ParentClass>(val);
+    }
+
+    NAN_INLINE static ParentClass* Unwrap(v8::Local<v8::Value> val) {
+      if(!val->IsObject()) {
+        char error[128];
+        snprintf(error, sizeof(error), "Cannot unwrap handle from non-object, expecting %s", ParentClass::ClassName());
+        Nan::ThrowTypeError(error);
+        return nullptr;
+      }
+
+      return Unwrap(val->ToObject());
+    }
+
+    NAN_INLINE static HandleType UnwrapHandle(v8::Local<v8::Value> val) {
+      return Unwrap(val)->virHandle();
+    }
+
+    template<class T>
+    NAN_INLINE static HandleType UnwrapHandle(v8::Local<v8::Object> val) {
+      return Unwrap(val)->virHandle();
+    }
+
+    virtual void ClearHandle() {
+      handle_.reset();
+    }
+
+    virtual void ClearChildren() {
+      std::vector<NLVObjectBasePtr*>::const_iterator it;
+      for (it = children_.begin(); it != children_.end(); ++it) {
+        NLVObjectBasePtr *ptr = *it;
+        if (ptr->IsValid()) {
+          NLVObjectBase *obj = ptr->GetPointer();
+          obj->ClearChildren();
+          obj->ClearHandle();
+          obj->SetParentReference(NULL);
+          delete ptr;
+        }
+      }
+
+      children_.clear();
+    }
+
+    virtual void SetParentReference(NLVObjectBasePtr *parentReference) {
+      parentReference_ = parentReference;
+    }
+
+  protected:
+    std::unique_ptr<HandleValue, decltype(&CleanupHandler::cleanup)> handle_;
+    NLVObjectBasePtr* parentReference_;
+
+  };
+
+  NAN_INLINE void AsyncQueueWorker(Nan::AsyncWorker *worker, Local<Object> parent = Local<Object>())
+  {
+    if (!parent->IsUndefined() && !parent->IsNull())
+      worker->SaveToPersistent("parent", parent);
+    Nan::AsyncQueueWorker(worker);
   }
-
-  virtual void SetParentReference(NLVObjectBasePtr *parentReference) {
-    parentReference_ = parentReference;
-  }
-
-protected:
-  std::unique_ptr<HandleValue, decltype(&CleanupHandler::cleanup)> handle_;
-  NLVObjectBasePtr* parentReference_;
-
-};
-
-namespace NLV {
-
-NAN_INLINE void AsyncQueueWorker(Nan::AsyncWorker *worker, Local<Object> parent = Local<Object>())
-{
-  if (!parent->IsUndefined() && !parent->IsNull())
-    worker->SaveToPersistent("parent", parent);
-  Nan::AsyncQueueWorker(worker);
-}
-
-NAN_INLINE unsigned int GetFlags(v8::Local<v8::Value> val) {
-  if(val->IsUndefined() || val->IsFunction()) {
-    return 0;
-  }
-  if(!val->IsArray()) {
-    Nan::ThrowTypeError("flags must be an array");
-    return 0;
-  }
-
-  Local<Array> flags_ = Local<Array>::Cast(val);
-  unsigned int flags = 0;
-  for (unsigned int i = 0; i < flags_->Length(); i++)
-    flags |= flags_->Get(Nan::New<Integer>(i))->Int32Value();
-  return flags;
-}
-
 };
 
 #endif  // NLV_OBJECT_H

--- a/src/utility.hpp
+++ b/src/utility.hpp
@@ -1,0 +1,62 @@
+#ifndef UTILITY_HPP
+#define UTILITY_HPP
+
+namespace NLV {    
+  namespace utility {
+    
+    // based on http://stackoverflow.com/a/6454211/403571
+    
+    using namespace std;
+    // ------------- UTILITY---------------
+    template<int...> struct index_tuple{}; 
+
+    template<int I, typename IndexTuple, typename... Types> 
+    struct make_indexes_impl; 
+
+    template<int I, int... Indexes, typename T, typename ... Types> 
+    struct make_indexes_impl<I, index_tuple<Indexes...>, T, Types...> 
+    { 
+        typedef typename make_indexes_impl<I + 1, index_tuple<Indexes..., I>, Types...>::type type; 
+    }; 
+
+    template<int I, int... Indexes> 
+    struct make_indexes_impl<I, index_tuple<Indexes...> > 
+    { 
+        typedef index_tuple<Indexes...> type; 
+    }; 
+
+    struct default_mapper {
+      template<typename T>
+      inline T operator()(T t) {
+        return t;
+      }
+    };
+
+    template<typename ... Types> 
+    struct make_indexes : make_indexes_impl<0, index_tuple<>, Types...> 
+    {}; 
+    
+    
+    #define __impl pf( MapFunc()(std::forward<decltype(get<Indexes>(tup))>(get<Indexes>(tup)))...)
+    template<class MapFunc, class Z, class... Args, int... Indexes > 
+    auto apply_helper( Z&& pf, index_tuple< Indexes... >, tuple<Args...>&& tup) -> decltype(__impl) 
+    { 
+        return __impl;
+    } 
+    #undef __impl
+
+    template<class MapFunc, class Z, class ... Args> 
+    auto apply(Z&& pf, const tuple<Args...>&  tup) -> decltype(apply_helper<MapFunc>(pf, typename make_indexes<Args...>::type(), tuple<Args...>(tup)))
+    {
+        return apply_helper<MapFunc>(pf, typename make_indexes<Args...>::type(), tuple<Args...>(tup));
+    }
+
+    template<class MapFunc = default_mapper, class Z, class ... Args> 
+    auto apply(Z&& pf, tuple<Args...>&&  tup) -> decltype(apply_helper<MapFunc>(pf, typename make_indexes<Args...>::type(), forward<tuple<Args...>>(tup)))
+    {
+        return apply_helper<MapFunc>(pf, typename make_indexes<Args...>::type(), forward<tuple<Args...>>(tup));
+    }
+  }
+};
+
+#endif // UTILITY_HPP

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -15,7 +15,7 @@ void Worker::RunAsync(const Nan::FunctionCallbackInfo<v8::Value>& info, ExecuteH
     return;
   }
 
-  Nan::Callback *callback = new Nan::Callback(v8_callback.As<Function>());
+  Nan::Callback *callback = new Nan::Callback(v8_callback.As<v8::Function>());
   auto worker = new NLV::Worker(callback, handler);
   auto parent = info.This();
   if (!parent->IsUndefined() && !parent->IsNull()) {

--- a/src/worker.h
+++ b/src/worker.h
@@ -44,10 +44,20 @@ namespace NLV {
   };
 
   template<class T>
-  Worker::OnFinishedHandler PrimitiveReturnHandler(T val) {
+  inline Worker::OnFinishedHandler PrimitiveReturnHandler(T val) {
     return [=](Worker* worker) {
       Nan::HandleScope scope;
       v8::Local<v8::Value> argv[] = { Nan::Null(), Nan::New(val) };
+      worker->Call(2, argv);
+    };
+  }
+
+  template<>
+  inline Worker::OnFinishedHandler PrimitiveReturnHandler(const char* val_) {
+    std::string val(val_);
+    return [=](Worker* worker) {
+      Nan::HandleScope scope;
+      v8::Local<v8::Value> argv[] = { Nan::Null(), Nan::New(val.c_str()).ToLocalChecked() };
       worker->Call(2, argv);
     };
   }

--- a/src/worker.h
+++ b/src/worker.h
@@ -1,6 +1,9 @@
+#ifndef WORKER_H
+#define WORKER_H
+
 #include <functional>
 
-#include "nlv_async_worker.h"
+#include "nlv_base.h"
 
 namespace NLV {
   class Worker : public NLVAsyncWorkerBase
@@ -55,8 +58,8 @@ namespace NLV {
       Nan::HandleScope scope;
       Nan::TryCatch try_catch;
 
-      Local<Object> childObject = T::NewInstance(val);
-      Local<Value> parentObject = worker->GetFromPersistent("parent");
+      v8::Local<v8::Object> childObject = T::NewInstance(val);
+      v8::Local<v8::Value> parentObject = worker->GetFromPersistent("parent");
       T* child = T::Unwrap(childObject);
       NLVObjectBasePtr* childPtr = new NLVObjectBasePtr(child);
       if (parentObject->IsObject()) {
@@ -81,3 +84,5 @@ namespace NLV {
     };
   }
 };
+
+#endif


### PR DESCRIPTION
So today I spent some time debugging my code only to find that I was running:
```
pool.refresh();
```
instead of:
```
pool.refreshAsync();
```

This was causing a crash in v8 as the first one did not pass  any callback and unfortunately that one piece of c++ code did not check if callback was there. I decided to build a simplified approach of defining Nan methods so in time most code and validations will be written only once.